### PR TITLE
feat: Add tsconfig paths configurations

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import "@/index.css";
 import type { Preview } from "@storybook/react";
 
 const preview: Preview = {

--- a/biome.json
+++ b/biome.json
@@ -4,6 +4,14 @@
     "ignoreUnknown": true,
     "includes": ["**", "!**/dist", "!**/.direnv"]
   },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
   "formatter": {
     "enabled": true,
     "formatWithErrors": true,
@@ -20,6 +28,17 @@
         "noUnusedImports": "error"
       },
       "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "patterns": [
+              {
+                "group": ["../**"],
+                "message": "Use @/ alias instead of relative parent imports."
+              }
+            ]
+          }
+        },
         "useSelfClosingElements": "error"
       },
       "suspicious": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
+import "@/index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@/index.css";
 import App from "@/App.tsx";
 
 const rootElement = document.getElementById("root");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {


### PR DESCRIPTION
## Summary

- tsconfig paths 설정을 추가해서 path 기반 import 대신 `@/`로 absolute import 하도록 수정했습니다.
- biome rule로 추가했고, `./`로 현재 폴더 내의 다른 모듈을 import 하는 경우는 허용됩니다. (`../` 상위 경로 relative import만 우선 차단)
- VSCode에서는 자동으로 `@/` absolute import를 이용해서 자동 완성될 거예요.

## Stacks

<!-- ejoffe/spr start -->
commit-id:3b477748

---

**Stack**:
- #31
- #30
- #29 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and linting configuration to enforce consistent import patterns across the codebase.
  * Consolidated stylesheet imports for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->