### PR TITLE
feat: ButtonBottom, ButtonBottomWithIcon 디자인 시스템 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     "@storybook/addon-onboarding",
     "@chromatic-com/storybook",
     "@storybook/experimental-addon-test",
+    "storybook-addon-pseudo-states",
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,13 @@
+@import "../src/index.css";
+
+/* https://github.com/storybookjs/storybook/issues/32443 */
+@custom-variant active (&:active);
+@custom-variant disabled (&:disabled);
+@custom-variant enabled (&:enabled);
+@custom-variant focus (&:focus);
+@custom-variant focus-visible (&:focus-visible);
+@custom-variant focus-within (&:focus-within);
+@custom-variant hover (&:hover);
+@custom-variant link (&:link);
+@custom-variant target (&:target);
+@custom-variant visited (&:visited);

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,4 @@
-import "@/index.css";
+import "./preview.css";
 import type { Preview } from "@storybook/react";
 
 const preview: Preview = {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "simple-git-hooks": "^2.13.1",
     "sort-package-json": "^3.6.0",
     "storybook": "8.6.15",
+    "storybook-addon-pseudo-states": "^4.0.4",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "vite": "^7.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       storybook:
         specifier: 8.6.15
         version: 8.6.15
+      storybook-addon-pseudo-states:
+        specifier: ^4.0.4
+        version: 4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -2344,6 +2347,11 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  storybook-addon-pseudo-states@4.0.4:
+    resolution: {integrity: sha512-hF3nLFpRPjqNxa7eqp+j1bd+DvyUCns1iesUZqMZz9ZuIijosOTQgJO5G0drbdxlHvXehu/BgcqbyxBb2eJR5w==}
+    peerDependencies:
+      storybook: ^8.2.0
 
   storybook@8.6.15:
     resolution: {integrity: sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==}
@@ -4677,6 +4685,14 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  storybook-addon-pseudo-states@4.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15):
+    dependencies:
+      '@storybook/icons': 1.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 8.6.15
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   storybook@8.6.15:
     dependencies:

--- a/src/assets/icons/placeholder.svg
+++ b/src/assets/icons/placeholder.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="3" width="14" height="14" rx="3" stroke="currentColor" stroke-linecap="round" stroke-dasharray="2 2"/>
+</svg>

--- a/src/shared/components/button-bottom-with-icon/index.stories.tsx
+++ b/src/shared/components/button-bottom-with-icon/index.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ButtonBottomWithIcon } from "@/shared/components/button-bottom-with-icon";
+import { PlaceholderIcon } from "@/shared/components/icons";
+
+const meta = {
+  title: "shared/ButtonBottomWithIcon",
+  component: ButtonBottomWithIcon,
+  args: { children: "Button", icon: <PlaceholderIcon /> },
+  argTypes: { icon: { control: false } },
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] px-5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof ButtonBottomWithIcon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const States: Story = {
+  render: () => {
+    const icon = <PlaceholderIcon />;
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <ButtonBottomWithIcon icon={icon} id="icon-default">
+          Default
+        </ButtonBottomWithIcon>
+        <ButtonBottomWithIcon icon={icon} id="icon-hover">
+          Hover
+        </ButtonBottomWithIcon>
+        <ButtonBottomWithIcon icon={icon} id="icon-pressed">
+          Pressed
+        </ButtonBottomWithIcon>
+      </div>
+    );
+  },
+  parameters: { pseudo: { active: "#icon-pressed", hover: "#icon-hover" } },
+};

--- a/src/shared/components/button-bottom-with-icon/index.tsx
+++ b/src/shared/components/button-bottom-with-icon/index.tsx
@@ -1,0 +1,35 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cn } from "@/shared/utils/cn";
+
+export interface ButtonBottomWithIconProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: ReactNode;
+}
+
+export function ButtonBottomWithIcon({
+  children,
+  className,
+  icon,
+  type = "button",
+  ...props
+}: ButtonBottomWithIconProps) {
+  return (
+    <button
+      className={cn(
+        "inline-flex h-[45px] w-full items-center justify-center gap-1.5 rounded-lg border border-k-200 bg-white px-4 text-b3 text-k-800 transition-colors enabled:cursor-pointer disabled:cursor-default",
+        "enabled:active:bg-k-50 enabled:hover:bg-k-10",
+        className,
+      )}
+      type={type}
+      {...props}
+    >
+      {children}
+      <span
+        aria-hidden
+        className="inline-flex shrink-0 items-center justify-center"
+      >
+        {icon}
+      </span>
+    </button>
+  );
+}

--- a/src/shared/components/button-bottom/index.stories.tsx
+++ b/src/shared/components/button-bottom/index.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ButtonBottom } from "@/shared/components/button-bottom";
+
+const meta = {
+  title: "shared/ButtonBottom",
+  component: ButtonBottom,
+  args: { children: "Button", variant: "black" },
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] px-5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof ButtonBottom>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const BlackStates: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-2">
+      <ButtonBottom id="black-default" variant="black">
+        Black / Default
+      </ButtonBottom>
+      <ButtonBottom id="black-hover" variant="black">
+        Black / Hover
+      </ButtonBottom>
+      <ButtonBottom id="black-pressed" variant="black">
+        Black / Pressed
+      </ButtonBottom>
+    </div>
+  ),
+  parameters: { pseudo: { active: "#black-pressed", hover: "#black-hover" } },
+};
+
+export const BlueStates: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-2">
+      <ButtonBottom id="blue-default" variant="blue">
+        Blue / Default
+      </ButtonBottom>
+      <ButtonBottom id="blue-hover" variant="blue">
+        Blue / Hover
+      </ButtonBottom>
+      <ButtonBottom id="blue-pressed" variant="blue">
+        Blue / Pressed
+      </ButtonBottom>
+    </div>
+  ),
+  parameters: { pseudo: { active: "#blue-pressed", hover: "#blue-hover" } },
+};
+
+export const WhiteStates: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-2 bg-k-10 p-3">
+      <ButtonBottom id="white-default" variant="white">
+        White / Default
+      </ButtonBottom>
+      <ButtonBottom id="white-hover" variant="white">
+        White / Hover
+      </ButtonBottom>
+      <ButtonBottom id="white-pressed" variant="white">
+        White / Pressed
+      </ButtonBottom>
+    </div>
+  ),
+  parameters: { pseudo: { active: "#white-pressed", hover: "#white-hover" } },
+};
+
+export const Disabled: Story = {
+  args: { children: "Disabled", disabled: true },
+};

--- a/src/shared/components/button-bottom/index.tsx
+++ b/src/shared/components/button-bottom/index.tsx
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ButtonHTMLAttributes } from "react";
+import { cn } from "@/shared/utils/cn";
+
+export const buttonBottomVariants = cva(
+  cn(
+    "inline-flex h-[54px] w-full cursor-pointer items-center justify-center rounded-lg border px-5 text-t2 transition-colors",
+    "disabled:cursor-not-allowed disabled:border-transparent disabled:bg-k-100 disabled:text-k-400",
+  ),
+  {
+    variants: {
+      variant: {
+        black:
+          "border-transparent bg-k-800 text-white enabled:active:bg-k-700 enabled:active:text-k-200 enabled:hover:bg-k-750",
+        blue: "border-transparent bg-primary-main text-white enabled:active:bg-p-500 enabled:hover:bg-p-450",
+        white:
+          "border-k-200 bg-k-5 text-k-800 enabled:active:bg-k-50 enabled:hover:bg-k-10",
+      },
+    },
+    defaultVariants: {
+      variant: "black",
+    },
+  },
+);
+
+export interface ButtonBottomProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonBottomVariants> {}
+
+export function ButtonBottom({
+  className,
+  type = "button",
+  variant,
+  ...props
+}: ButtonBottomProps) {
+  return (
+    <button
+      className={cn(buttonBottomVariants({ variant }), className)}
+      type={type}
+      {...props}
+    />
+  );
+}

--- a/src/shared/components/icon-button/index.stories.tsx
+++ b/src/shared/components/icon-button/index.stories.tsx
@@ -1,13 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import ChevronDownIcon from "@/assets/icons/chevron-down.svg?react";
-import ChevronLeftIcon from "@/assets/icons/chevron-left.svg?react";
-import ChevronRightIcon from "@/assets/icons/chevron-right.svg?react";
-import ChevronUpIcon from "@/assets/icons/chevron-up.svg?react";
-import CloseIcon from "@/assets/icons/close.svg?react";
-import MinusIcon from "@/assets/icons/minus.svg?react";
-import PlusIcon from "@/assets/icons/plus.svg?react";
-import ShareIcon from "@/assets/icons/share.svg?react";
 import { IconButton } from "@/shared/components/icon-button";
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  CloseIcon,
+  MinusIcon,
+  PlusIcon,
+  ShareIcon,
+} from "@/shared/components/icons";
 
 const meta = {
   title: "shared/IconButton",

--- a/src/shared/components/icons/index.tsx
+++ b/src/shared/components/icons/index.tsx
@@ -10,6 +10,7 @@ export { default as CloseIcon } from "@/assets/icons/close.svg?react";
 export { default as ErrorIcon } from "@/assets/icons/error.svg?react";
 export { default as MemberIcon } from "@/assets/icons/member.svg?react";
 export { default as MinusIcon } from "@/assets/icons/minus.svg?react";
+export { default as PlaceholderIcon } from "@/assets/icons/placeholder.svg?react";
 export { default as PlusIcon } from "@/assets/icons/plus.svg?react";
 export { default as ShareIcon } from "@/assets/icons/share.svg?react";
 export { default as TimeIcon } from "@/assets/icons/time.svg?react";


### PR DESCRIPTION
## Summary

- `ButtonBottom` 및 `ButtonBottomWithIcon` 컴포넌트를 구현했습니다.
- `storybook-addon-pseudo-states`을 추가해서 Storybook에서 특정 상태를 고정으로 디자인 테스트할 수 있도록 개선했습니다. (ex. `:hover` 상태로 컴포넌트를 고정)

## Screenshots

| component | component |
| - | - |
| <img width="411" height="238" alt="CleanShot 2026-02-14 at 04 24 47" src="https://github.com/user-attachments/assets/4177329e-085a-4f14-b85f-71fa08e50025" /> | <img width="401" height="241" alt="CleanShot 2026-02-14 at 04 24 51" src="https://github.com/user-attachments/assets/a9c85e63-d484-45e8-bc42-d4f89dbb3e2c" /> |
| <img width="393" height="254" alt="CleanShot 2026-02-14 at 04 24 56" src="https://github.com/user-attachments/assets/00e2bf00-c541-4558-8049-7cbb4d9a4269" /> | <img width="426" height="127" alt="CleanShot 2026-02-14 at 04 25 00" src="https://github.com/user-attachments/assets/4d6c686a-653f-49a0-a14c-3f5483dc45f2" /> |

서비스에서는 공유 버튼 + 하단 버튼을 함께 조합해서 사용하는데, 이 부분은 디자인 시스템에서는 구현하지 않았고 예시 코드는 #59 PR의 설명과 아래 코드를 참고해주세요.

https://github.com/dnd-side-project/dnd-14th-8-frontend/blob/6e2aa623866119da7f92012394092e6e6248705a/src/shared/components/toast/index.stories.tsx#L58-L63

## References

- closes #34

## Stacks

<!-- ejoffe/spr start -->
commit-id:2b106dd6

---

**Stack**:
- #60
- #57
- #52
- #50
- #59
- #47 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ButtonBottom (color variants + disabled) and ButtonBottomWithIcon components for consistent button options.
* **Tests**
  * Added Storybook stories showcasing playground, color states, disabled state, and icon variants with interactive pseudo-states.
* **Chores**
  * Enabled pseudo-state simulation in Storybook (addon added) and updated Storybook to load a dedicated preview stylesheet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->