### PR TITLE
feat: GuideTimeSelection 디자인 시스템 구현

### DIFF
--- a/src/domains/schedule/components/guide-time-selection/index.stories.tsx
+++ b/src/domains/schedule/components/guide-time-selection/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { GuideTimeSelection } from "@/domains/schedule/components/guide-time-selection";
+
+const meta = {
+  title: "domains/schedule/GuideTimeSelection",
+  component: GuideTimeSelection,
+  decorators: [
+    (Story) => (
+      <div className="w-[375px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof GuideTimeSelection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/domains/schedule/components/guide-time-selection/index.tsx
+++ b/src/domains/schedule/components/guide-time-selection/index.tsx
@@ -1,0 +1,66 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/shared/utils/cn";
+
+interface GuideLegendItemProps extends HTMLAttributes<HTMLSpanElement> {
+  checked?: boolean;
+  children: ReactNode;
+}
+
+export interface GuideTimeSelectionProps
+  extends HTMLAttributes<HTMLDivElement> {
+  availableLabel?: ReactNode;
+  description?: ReactNode;
+  unavailableLabel?: ReactNode;
+}
+
+function GuideLegendItem({
+  checked = false,
+  children,
+  className,
+  ...props
+}: GuideLegendItemProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex w-fit select-none items-center gap-1.5 text-b5 text-k-500",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "inline-flex size-3 shrink-0 rounded-[3.43px] border transition-colors",
+          checked && "border-primary-main bg-primary-main",
+          !checked && "border-k-100 bg-k-10",
+        )}
+      />
+      {children}
+    </span>
+  );
+}
+
+export function GuideTimeSelection({
+  availableLabel = "가능",
+  className,
+  description = "클릭하거나 쓸어내려 가능 시간대를 지정해보세요",
+  unavailableLabel = "불가",
+  ...props
+}: GuideTimeSelectionProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-1 bg-transparent",
+        className,
+      )}
+      data-slot="guide-time-selection"
+      {...props}
+    >
+      <p className="text-b4 text-k-600">{description}</p>
+      <div className="flex items-center gap-3">
+        <GuideLegendItem checked={true}>{availableLabel}</GuideLegendItem>
+        <GuideLegendItem checked={false}>{unavailableLabel}</GuideLegendItem>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- 가이드 관련 디자인 시스템 컴포넌트를 구현했습니다.
- 일정 조율에만 사용될 것 같아서, `domains/schedule` 를 새로 만들어 배치했습니다.

## Screenshots

<img width="338" height="93" alt="CleanShot 2026-02-14 at 04 29 51" src="https://github.com/user-attachments/assets/84c76b8c-ac53-409b-90ef-4083e930490d" />

## References

- closes #39

## Stacks

<!-- ejoffe/spr start -->
commit-id:ad065afb

---

**Stack**:
- #60
- #59
- #58
- #57
- #55
- #54
- #52
- #50
- #47
- #53
- #56
- #49 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Guide Time Selection component that displays a visual legend showing available and unavailable time slots with customizable labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->