### PR TITLE
feat: IconButton 디자인 시스템 구현

### DIFF
--- a/src/shared/components/icon-button/index.stories.tsx
+++ b/src/shared/components/icon-button/index.stories.tsx
@@ -1,0 +1,459 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ChevronDownIcon from "@/assets/icons/chevron-down.svg?react";
+import ChevronLeftIcon from "@/assets/icons/chevron-left.svg?react";
+import ChevronRightIcon from "@/assets/icons/chevron-right.svg?react";
+import ChevronUpIcon from "@/assets/icons/chevron-up.svg?react";
+import CloseIcon from "@/assets/icons/close.svg?react";
+import MinusIcon from "@/assets/icons/minus.svg?react";
+import PlusIcon from "@/assets/icons/plus.svg?react";
+import ShareIcon from "@/assets/icons/share.svg?react";
+import { IconButton } from "@/shared/components/icon-button";
+
+const meta = {
+  title: "shared/IconButton",
+  component: IconButton,
+  args: {
+    icon: PlusIcon,
+    size: "xl",
+    background: "square",
+    backgroundSize: "md",
+    iconSize: "lg",
+    variant: "primary",
+  },
+  argTypes: {
+    icon: {
+      control: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] px-5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const PseudoStatesTest: Story = {
+  render: () => (
+    <div className="flex flex-col items-center gap-6">
+      {/* Background Square Tests */}
+      <div className="flex items-center gap-4">
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">Square Normal</p>
+          <IconButton
+            icon={PlusIcon}
+            size="xl"
+            background="square"
+            backgroundSize="md"
+            iconSize="lg"
+            variant="primary"
+          />
+        </div>
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">Square Manual Hover</p>
+          <IconButton
+            id="btn-square-manual-hover"
+            icon={PlusIcon}
+            size="xl"
+            background="square"
+            backgroundSize="md"
+            iconSize="lg"
+            variant="primary"
+          />
+        </div>
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">Square Dark</p>
+          <IconButton
+            icon={PlusIcon}
+            size="xl"
+            background="square"
+            backgroundSize="md"
+            iconSize="lg"
+            variant="dark"
+          />
+        </div>
+      </div>
+
+      {/* Background None Tests */}
+      <div className="flex items-center gap-4">
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">None Normal</p>
+          <IconButton
+            icon={CloseIcon}
+            size="lg"
+            background="none"
+            iconSize="lg"
+            variant="primary"
+          />
+        </div>
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">None Hover</p>
+          <IconButton
+            id="btn-none-hover"
+            icon={CloseIcon}
+            size="lg"
+            background="none"
+            iconSize="lg"
+            variant="primary"
+          />
+        </div>
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">None Neutral</p>
+          <IconButton
+            icon={CloseIcon}
+            size="lg"
+            background="none"
+            iconSize="lg"
+            variant="neutral"
+          />
+        </div>
+      </div>
+
+      {/* Circle Tests */}
+      <div className="flex items-center gap-4">
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">Circle Normal</p>
+          <IconButton
+            icon={CloseIcon}
+            size="xl"
+            background="circle"
+            backgroundSize="xs"
+            iconSize="xs"
+            variant="neutral"
+          />
+        </div>
+        <div className="text-center">
+          <p className="mb-2 text-k-600 text-sm">Circle Hover</p>
+          <IconButton
+            id="btn-circle-hover"
+            icon={CloseIcon}
+            size="xl"
+            background="circle"
+            backgroundSize="xs"
+            iconSize="xs"
+            variant="neutral"
+          />
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      hover: [
+        "#btn-square-hover",
+        "#btn-none-hover",
+        "#btn-circle-hover",
+        "#btn-square-manual-hover",
+      ],
+      active: [],
+    },
+  },
+};
+
+export const Designs: Story = {
+  render: () => (
+    <div className="flex w-full flex-col items-start gap-4">
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Plus</span>
+        <IconButton
+          icon={PlusIcon}
+          size="xl"
+          background="square"
+          backgroundSize="md"
+          iconSize="lg"
+          variant="primary"
+          title="Normal state"
+        />
+        <IconButton
+          id="icon-plus-hover"
+          icon={PlusIcon}
+          size="xl"
+          background="square"
+          backgroundSize="md"
+          iconSize="lg"
+          variant="primary"
+          title="Hover state"
+        />
+        <IconButton
+          id="icon-plus-pressed"
+          icon={PlusIcon}
+          size="xl"
+          background="square"
+          backgroundSize="md"
+          iconSize="lg"
+          variant="primary"
+          title="Active/Pressed state"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Minus</span>
+        <IconButton
+          icon={MinusIcon}
+          size="xl"
+          background="square"
+          backgroundSize="md"
+          iconSize="lg"
+          variant="surface"
+        />
+        <IconButton
+          id="icon-minus-hover"
+          icon={MinusIcon}
+          size="xl"
+          background="square"
+          backgroundSize="md"
+          iconSize="lg"
+          variant="surface"
+        />
+        <IconButton
+          id="icon-minus-pressed"
+          icon={MinusIcon}
+          size="xl"
+          background="square"
+          backgroundSize="md"
+          iconSize="lg"
+          variant="surface"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Delete</span>
+        <IconButton
+          icon={CloseIcon}
+          size="xl"
+          background="circle"
+          backgroundSize="xs"
+          iconSize="xs"
+          variant="gray"
+        />
+        <IconButton
+          id="icon-delete-hover"
+          icon={CloseIcon}
+          size="xl"
+          background="circle"
+          backgroundSize="xs"
+          iconSize="xs"
+          variant="gray"
+        />
+        <IconButton
+          id="icon-delete-pressed"
+          icon={CloseIcon}
+          size="xl"
+          background="circle"
+          backgroundSize="xs"
+          iconSize="xs"
+          variant="gray"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Share</span>
+        <IconButton
+          icon={ShareIcon}
+          size="2xl"
+          background="square"
+          backgroundSize="lg"
+          iconSize="xl"
+          variant="dark"
+        />
+        <IconButton
+          id="icon-share-hover"
+          icon={ShareIcon}
+          size="2xl"
+          background="square"
+          backgroundSize="lg"
+          iconSize="xl"
+          variant="dark"
+        />
+        <IconButton
+          id="icon-share-pressed"
+          icon={ShareIcon}
+          size="2xl"
+          background="square"
+          backgroundSize="lg"
+          iconSize="xl"
+          variant="dark"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Close</span>
+        <IconButton
+          icon={CloseIcon}
+          size="lg"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-close-hover"
+          icon={CloseIcon}
+          size="lg"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-close-pressed"
+          icon={CloseIcon}
+          size="lg"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Close Circle</span>
+        <IconButton
+          icon={CloseIcon}
+          size="lg"
+          background="circle"
+          backgroundSize="sm"
+          iconSize="sm"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-close-circle-hover"
+          icon={CloseIcon}
+          size="lg"
+          background="circle"
+          backgroundSize="sm"
+          iconSize="sm"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-close-circle-pressed"
+          icon={CloseIcon}
+          size="lg"
+          background="circle"
+          backgroundSize="sm"
+          iconSize="sm"
+          variant="neutral"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Chevron Up/Down</span>
+        <IconButton
+          icon={ChevronUpIcon}
+          size="sm"
+          background="none"
+          iconSize="md"
+          variant="neutral"
+        />
+        <IconButton
+          icon={ChevronDownIcon}
+          size="sm"
+          background="none"
+          iconSize="md"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-chevron-v-hover"
+          icon={ChevronUpIcon}
+          size="sm"
+          background="none"
+          iconSize="md"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-chevron-v-pressed"
+          icon={ChevronDownIcon}
+          size="sm"
+          background="none"
+          iconSize="md"
+          variant="neutral"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Chevron Left/Right</span>
+        <IconButton
+          icon={ChevronLeftIcon}
+          size="md"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+        <IconButton
+          icon={ChevronRightIcon}
+          size="md"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-chevron-h-hover"
+          icon={ChevronRightIcon}
+          size="md"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+        <IconButton
+          id="icon-chevron-h-pressed"
+          icon={ChevronLeftIcon}
+          size="md"
+          background="none"
+          iconSize="lg"
+          variant="neutral"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="w-20 text-k-500 text-sm">Chevron Calendar</span>
+        <IconButton
+          icon={ChevronLeftIcon}
+          size="md"
+          background="square"
+          backgroundSize="sm"
+          iconSize="lg"
+          variant="subtle"
+        />
+        <IconButton
+          icon={ChevronRightIcon}
+          size="md"
+          background="square"
+          backgroundSize="sm"
+          iconSize="lg"
+          variant="subtle"
+        />
+        <IconButton
+          id="icon-chevron-calendar-h-hover"
+          icon={ChevronRightIcon}
+          size="md"
+          background="square"
+          backgroundSize="sm"
+          iconSize="lg"
+          variant="subtle"
+        />
+        <IconButton
+          id="icon-chevron-calendar-h-pressed"
+          icon={ChevronLeftIcon}
+          size="md"
+          background="square"
+          backgroundSize="sm"
+          iconSize="lg"
+          variant="subtle"
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      hover:
+        "#icon-plus-hover, #icon-minus-hover, #icon-delete-hover, #icon-share-hover, #icon-close-hover, #icon-close-circle-hover, #icon-chevron-v-hover, #icon-chevron-h-hover, #icon-chevron-calendar-h-hover",
+      active:
+        "#icon-plus-pressed, #icon-minus-pressed, #icon-delete-pressed, #icon-share-pressed, #icon-close-pressed, #icon-close-circle-pressed, #icon-chevron-v-pressed, #icon-chevron-h-pressed, #icon-chevron-calendar-h-pressed",
+    },
+  },
+};

--- a/src/shared/components/icon-button/index.tsx
+++ b/src/shared/components/icon-button/index.tsx
@@ -1,0 +1,179 @@
+import { cva } from "class-variance-authority";
+import {
+  type ButtonHTMLAttributes,
+  type ComponentType,
+  type SVGProps,
+  useMemo,
+} from "react";
+import { cn } from "@/shared/utils/cn";
+
+const iconButtonVariants = cva(
+  "group inline-flex cursor-pointer items-center justify-center transition-colors",
+  {
+    variants: {
+      size: {
+        sm: "size-8", // 32px
+        md: "size-9", // 36px
+        lg: "size-10", // 40px
+        xl: "size-12", // 48px
+        "2xl": "size-[54px]", // 54px
+      },
+      background: { none: "", circle: "", square: "" },
+      variant: {
+        primary: "text-k-5",
+        surface: "text-k-500",
+        dark: "text-white",
+        gray: "text-k-5",
+        neutral: "text-k-500",
+        subtle: "text-k-700",
+      },
+    },
+    compoundVariants: [
+      {
+        background: "none",
+        variant: "primary",
+        class: "enabled:active:text-p-500 enabled:hover:text-p-450",
+      },
+      {
+        background: "none",
+        variant: "surface",
+        class: "enabled:active:text-k-800 enabled:hover:text-k-700",
+      },
+      {
+        background: "none",
+        variant: "dark",
+        class: "enabled:active:text-k-700 enabled:hover:text-k-750",
+      },
+      {
+        background: "none",
+        variant: "neutral",
+        class: "enabled:active:text-k-800 enabled:hover:text-k-700",
+      },
+      {
+        background: "none",
+        variant: "subtle",
+        class: "enabled:active:text-k-900 enabled:hover:text-k-800",
+      },
+    ],
+    defaultVariants: {
+      size: "lg",
+      background: "none",
+      variant: "neutral",
+    },
+  },
+);
+
+const backgroundVariants = cva(
+  "flex items-center justify-center transition-colors",
+  {
+    variants: {
+      background: {
+        circle: "rounded-full",
+        square: "rounded-lg",
+      },
+      backgroundSize: {
+        xs: "size-5", // 20px
+        sm: "size-7", // 28px
+        md: "size-8", // 32px
+        lg: "size-[54px]", // 54px
+      },
+      variant: {
+        primary:
+          "bg-primary-main transition-colors group-enabled:group-active:bg-p-500 group-enabled:group-hover:bg-p-450",
+        surface:
+          "bg-k-5 transition-colors group-enabled:group-active:bg-k-200 group-enabled:group-hover:bg-k-100",
+        dark: "bg-k-800 transition-colors group-enabled:group-active:bg-k-700 group-enabled:group-hover:bg-k-750",
+        gray: "bg-k-300 transition-colors group-enabled:group-active:bg-k-500 group-enabled:group-hover:bg-k-400",
+        neutral:
+          "bg-k-100 transition-colors group-enabled:group-active:bg-k-300 group-enabled:group-hover:bg-k-200",
+        subtle:
+          "transition-colors group-enabled:group-active:bg-k-50 group-enabled:group-hover:bg-k-10",
+      },
+    },
+    defaultVariants: {
+      background: "square",
+      backgroundSize: "md",
+      variant: "primary",
+    },
+  },
+);
+
+const iconVariants = cva("shrink-0", {
+  variants: {
+    iconSize: {
+      xs: "size-[15px]", // 15px
+      sm: "size-4", // 16px
+      md: "size-5", // 20px
+      lg: "size-6", // 24px
+      xl: "size-9", // 36px
+    },
+  },
+  defaultVariants: {
+    iconSize: "xs",
+  },
+});
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface IconButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: IconComponent;
+  size: "sm" | "md" | "lg" | "xl" | "2xl";
+  background?: "none" | "circle" | "square";
+  backgroundSize?: "xs" | "sm" | "md" | "lg";
+  iconSize: "xs" | "sm" | "md" | "lg" | "xl";
+  variant?: "primary" | "surface" | "dark" | "gray" | "neutral" | "subtle";
+  iconClassName?: string;
+}
+
+export function IconButton({
+  type = "button",
+  size,
+  variant,
+  background = "none",
+  backgroundSize = "md",
+  icon: Icon,
+  iconSize,
+  iconClassName,
+  className,
+  ...props
+}: IconButtonProps) {
+  const buttonVariant =
+    background === "none" ? variant || "neutral" : variant || "primary";
+
+  const icon = useMemo(
+    () => (
+      <Icon
+        aria-hidden
+        className={cn(iconVariants({ iconSize }), iconClassName)}
+      />
+    ),
+    [iconSize, iconClassName],
+  );
+
+  return (
+    <button
+      className={cn(
+        iconButtonVariants({ size, background, variant: buttonVariant }),
+        className,
+      )}
+      type={type}
+      {...props}
+    >
+      {background === "none" && icon}
+      {background !== "none" && (
+        <div
+          className={cn(
+            backgroundVariants({
+              background,
+              backgroundSize,
+              variant: buttonVariant,
+            }),
+          )}
+        >
+          {icon}
+        </div>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Icon만 포함되는 버튼을 위해 IconButton 컴포넌트를 구현했습니다.
- button > div > icon의 구조로 이루어져 있습니다.
  - button은 사용자가 클릭 가능한 영역 및 onClick 핸들러를 달기 위해 존재함
  - div는 background color가 표시되어야 하는 영역을 지정하기 위해 존재함 (배경이 없는 경우는 생략함)
  - icon은 아이콘 svgr로 import 해온 컴포넌트가 위치함

## Screenshots

<img width="752" height="1192" alt="CleanShot 2026-02-15 at 00 12 07@2x" src="https://github.com/user-attachments/assets/ff6bd083-c696-449e-8496-3baea36f1fe2" />

## References

- closes #39

## Stacks

<!-- ejoffe/spr start -->
commit-id:bcfcfaa4

---

**Stack**:
- #60
- #59
- #58
- #57
- #55
- #54
- #52
- #50
- #47
- #53
- #56 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced IconButton component with customizable sizing, background styles, and visual variants for enhanced UI flexibility.

* **Documentation**
  * Added comprehensive Storybook stories showcasing IconButton states and design variants for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->