### PR TITLE
feat: Calendar 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "react": "^19.2.3",
+    "react-day-picker": "^9.13.2",
     "react-dom": "^19.2.3",
     "react-router": "^7.13.0",
     "sonner": "^2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react:
         specifier: ^19.2.3
         version: 19.2.3
+      react-day-picker:
+        specifier: ^9.13.2
+        version: 9.13.2(react@19.2.3)
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
@@ -270,6 +273,9 @@ packages:
     engines: {node: '>=16.0.0', yarn: '>=1.22.18'}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1546,6 +1552,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -2233,6 +2242,12 @@ packages:
     peerDependencies:
       react: ^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0
 
+  react-day-picker@9.13.2:
+    resolution: {integrity: sha512-IMPiXfXVIAuR5Yk58DDPBC8QKClrhdXV+Tr/alBrwrHUw0qDDYB1m5zPNuTnnPIr/gmJ4ChMxmtqPdxm8+R4Eg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
@@ -2834,6 +2849,8 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
       - react
+
+  '@date-fns/tz@1.4.1': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3924,6 +3941,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  date-fns-jalali@4.1.0-0: {}
+
   date-fns@4.1.0: {}
 
   debug@4.4.3:
@@ -4558,6 +4577,13 @@ snapshots:
     dependencies:
       react: 19.2.3
       tween-functions: 1.2.0
+
+  react-day-picker@9.13.2(react@19.2.3):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.3
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:

--- a/src/shared/components/calendar/class-names.ts
+++ b/src/shared/components/calendar/class-names.ts
@@ -1,0 +1,59 @@
+import type {
+  DayPickerProps,
+  getDefaultClassNames,
+  PropsBase,
+} from "react-day-picker";
+import { cn } from "@/shared/utils/cn";
+
+type CalendarClassNamesParams = {
+  classNames?: PropsBase["classNames"];
+  defaultClassNames: ReturnType<typeof getDefaultClassNames>;
+};
+
+const buttonBaseClassName = cn(
+  "relative isolate text-k-700 aria-disabled:pointer-events-none aria-disabled:cursor-default aria-disabled:text-k-200",
+);
+
+export function getCalendarClassNames({
+  classNames,
+  defaultClassNames,
+}: CalendarClassNamesParams): DayPickerProps["classNames"] {
+  return {
+    root: cn("w-[335px]", defaultClassNames.root),
+    months: cn("relative w-full", defaultClassNames.months),
+    month: cn("w-full", defaultClassNames.month),
+    month_caption: cn(
+      "relative flex h-11 items-center justify-start",
+      defaultClassNames.month_caption,
+    ),
+    caption_label: cn("text-k-700 text-t2", defaultClassNames.caption_label),
+    nav: cn(
+      "absolute top-[18px] right-[6px] z-1 flex -translate-y-1/2 items-center gap-1",
+      defaultClassNames.nav,
+    ),
+    button_previous: cn(buttonBaseClassName, defaultClassNames.button_previous),
+    button_next: cn(buttonBaseClassName, defaultClassNames.button_next),
+    month_grid: cn(
+      "w-full table-fixed border-collapse",
+      defaultClassNames.month_grid,
+    ),
+    weekdays: cn("h-11", defaultClassNames.weekdays),
+    weekday: cn(
+      "h-11 p-0 text-center align-middle text-b4 text-k-500",
+      defaultClassNames.weekday,
+    ),
+    week: cn("h-11", defaultClassNames.week),
+    day: cn(
+      "group/day relative h-11 p-0 text-center align-middle text-k-900 before:pointer-events-none before:absolute before:top-1/2 before:left-1/2 before:size-10 before:-translate-x-1/2 before:-translate-y-1/2 before:scale-[0.96] before:rounded-lg before:bg-primary-main before:opacity-0 before:transition-[transform,opacity] before:duration-140 before:ease-[cubic-bezier(0.2,0.8,0.2,1)] data-[disabled=true]:text-k-200 data-[outside=true]:text-k-200 data-[selected=true]:before:scale-100 data-[selected=true]:before:opacity-100",
+      defaultClassNames.day,
+    ),
+    day_button: cn(
+      "relative z-1 mx-auto inline-flex size-10 cursor-pointer items-center justify-center rounded-lg p-0 text-b2 outline-none transition-colors focus:outline-none focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-0 disabled:cursor-default disabled:text-k-200 aria-disabled:cursor-default aria-disabled:text-k-200 group-data-[selected=true]/day:text-k-5",
+      defaultClassNames.day_button,
+    ),
+    outside: defaultClassNames.outside,
+    disabled: defaultClassNames.disabled,
+    hidden: cn("invisible", defaultClassNames.hidden),
+    ...classNames,
+  };
+}

--- a/src/shared/components/calendar/drag-selection-utils.ts
+++ b/src/shared/components/calendar/drag-selection-utils.ts
@@ -1,0 +1,78 @@
+import { eachDayOfInterval, format, isAfter } from "date-fns";
+import type { Modifiers } from "react-day-picker";
+
+export type DragSelectionMode = "add" | "remove";
+
+export type CalendarDayMeta = {
+  date: Date;
+  isBlocked: boolean;
+  isSelected: boolean;
+};
+
+export function getCalendarDateKey(date: Date) {
+  return format(date, "yyyy-MM-dd");
+}
+
+function parseCalendarDateKey(dateKey: string) {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function getRangeDates(from: Date, to: Date) {
+  if (isAfter(from, to)) {
+    return eachDayOfInterval({ start: to, end: from });
+  } else {
+    return eachDayOfInterval({ start: from, end: to });
+  }
+}
+
+export function isBlockedDay(modifiers: Modifiers) {
+  return modifiers.disabled || modifiers.hidden;
+}
+
+export function getCalendarDayMeta(
+  calendarId: string,
+  target: EventTarget | null,
+): CalendarDayMeta | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  const calendarRoot = document.getElementById(calendarId);
+  if (!calendarRoot) {
+    return null;
+  }
+
+  const dayCell = target.closest<HTMLElement>("[data-day]");
+  if (!dayCell || !calendarRoot.contains(dayCell)) {
+    return null;
+  }
+
+  const dateKey = dayCell.dataset.day;
+  if (!dateKey) {
+    return null;
+  }
+
+  return {
+    date: parseCalendarDateKey(dateKey),
+    isBlocked:
+      dayCell.dataset.disabled === "true" || dayCell.dataset.hidden === "true",
+    isSelected: dayCell.dataset.selected === "true",
+  };
+}
+
+export function getDraggedSelection(
+  baseDates: Date[],
+  startDate: Date,
+  currentDate: Date,
+  dragMode: DragSelectionMode,
+) {
+  const rangeDates = getRangeDates(startDate, currentDate);
+
+  if (dragMode === "remove") {
+    const keys = new Set(rangeDates.map(getCalendarDateKey));
+    return baseDates.filter((date) => !keys.has(getCalendarDateKey(date)));
+  } else {
+    return [...baseDates, ...rangeDates];
+  }
+}

--- a/src/shared/components/calendar/index.stories.tsx
+++ b/src/shared/components/calendar/index.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { addMonths, endOfMonth } from "date-fns";
+import { ko } from "date-fns/locale";
+import { Calendar } from "@/shared/components/calendar";
+
+const toDates = (days: number[]) => days.map((day) => new Date(2026, 11, day));
+
+const meta = {
+  title: "shared/Calendar",
+  component: Calendar,
+  args: {
+    defaultMonth: new Date(2026, 11, 1),
+    locale: ko,
+    showOutsideDays: true,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] px-5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Calendar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { defaultSelected: toDates([16]) } };
+
+export const DateSelected: Story = {
+  args: {
+    defaultSelected: toDates([
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+    ]),
+  },
+};
+
+export const MixedSelected: Story = {
+  args: { defaultSelected: toDates([16, 18, 21, 23, 27, 30]) },
+};
+
+export const FromCurrentMonth: Story = {
+  render: (args) => {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const currentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    return <Calendar {...args} defaultMonth={currentMonth} startDate={today} />;
+  },
+};
+
+export const BoundedMonthRange: Story = {
+  render: (args) => {
+    const now = new Date();
+    const currentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    return (
+      <Calendar
+        {...args}
+        defaultMonth={currentMonth}
+        endDate={endOfMonth(addMonths(currentMonth, 2))}
+        startDate={currentMonth}
+      />
+    );
+  },
+};

--- a/src/shared/components/calendar/index.tsx
+++ b/src/shared/components/calendar/index.tsx
@@ -1,0 +1,159 @@
+import { format } from "date-fns";
+import type { Locale } from "date-fns/locale";
+import { ko } from "date-fns/locale";
+import { type ComponentProps, useId } from "react";
+import type { Matcher, PropsBase } from "react-day-picker";
+import { DayPicker, getDefaultClassNames } from "react-day-picker";
+import { IconButton } from "@/shared/components/icon-button";
+import { ChevronLeftIcon, ChevronRightIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+import { getCalendarClassNames } from "./class-names";
+import { useCalendarSelection } from "./use-calendar-selection";
+
+export type CalendarProps = Omit<
+  PropsBase,
+  "components" | "endMonth" | "locale" | "mode" | "required" | "startMonth"
+> & {
+  defaultSelected?: Date[];
+  enableDragSelection?: boolean;
+  endDate?: Date;
+  locale?: Locale;
+  onSelect?: (dates: Date[]) => void;
+  selected?: Date[];
+  startDate?: Date;
+};
+
+type CalendarNavButtonProps = ComponentProps<"button">;
+
+function toCalendarDate(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function toMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function createCalendarNavButton(icon: typeof ChevronLeftIcon) {
+  return function CalendarNavButton({
+    className,
+    type = "button",
+    ...props
+  }: CalendarNavButtonProps) {
+    return (
+      <IconButton
+        {...props}
+        size="md"
+        background="square"
+        backgroundSize="sm"
+        icon={icon}
+        iconSize="lg"
+        iconClassName="relative z-1"
+        type={type}
+        variant="subtle"
+        className={className}
+      />
+    );
+  };
+}
+
+const CalendarNextMonthButton = createCalendarNavButton(ChevronRightIcon);
+const CalendarPreviousMonthButton = createCalendarNavButton(ChevronLeftIcon);
+
+export function Calendar({
+  className,
+  classNames,
+  defaultSelected,
+  disabled,
+  enableDragSelection = true,
+  endDate,
+  formatters,
+  id,
+  locale = ko,
+  onDayClick,
+  onDayMouseEnter,
+  onSelect,
+  selected,
+  showOutsideDays = true,
+  startDate,
+  ...props
+}: CalendarProps) {
+  const defaultClassNames = getDefaultClassNames();
+  const generatedCalendarId = useId();
+  const calendarId = id ?? generatedCalendarId;
+
+  const {
+    handleDayMouseEnter: onCalendarDayMouseEnter,
+    handleSelect,
+    selectedDates,
+  } = useCalendarSelection({
+    calendarId,
+    defaultSelected,
+    enableDragSelection,
+    onDayMouseEnter,
+    onSelect,
+    selected,
+  });
+
+  const normalizedStartDate = startDate ? toCalendarDate(startDate) : undefined;
+  const normalizedEndDate = endDate ? toCalendarDate(endDate) : undefined;
+
+  const minDate =
+    normalizedStartDate &&
+    normalizedEndDate &&
+    normalizedStartDate.getTime() > normalizedEndDate.getTime()
+      ? normalizedEndDate
+      : normalizedStartDate;
+  const maxDate =
+    normalizedStartDate &&
+    normalizedEndDate &&
+    normalizedStartDate.getTime() > normalizedEndDate.getTime()
+      ? normalizedStartDate
+      : normalizedEndDate;
+
+  const rangeDisabled: Matcher[] = [];
+
+  if (minDate) {
+    rangeDisabled.push({ before: minDate });
+  }
+
+  if (maxDate) {
+    rangeDisabled.push({ after: maxDate });
+  }
+
+  const mergedDisabled =
+    rangeDisabled.length === 0
+      ? disabled
+      : disabled === undefined
+        ? rangeDisabled
+        : Array.isArray(disabled)
+          ? [...disabled, ...rangeDisabled]
+          : [disabled, ...rangeDisabled];
+
+  return (
+    <DayPicker
+      {...props}
+      components={{
+        NextMonthButton: CalendarNextMonthButton,
+        PreviousMonthButton: CalendarPreviousMonthButton,
+      }}
+      disabled={mergedDisabled}
+      formatters={{
+        formatCaption: (displayMonth) =>
+          format(displayMonth, "yyyy년 M월", { locale }),
+        ...formatters,
+      }}
+      endMonth={maxDate ? toMonth(maxDate) : undefined}
+      id={calendarId}
+      locale={locale}
+      mode="multiple"
+      onDayClick={onDayClick}
+      onDayMouseEnter={onCalendarDayMouseEnter}
+      onSelect={handleSelect}
+      selected={selectedDates}
+      showOutsideDays={showOutsideDays}
+      startMonth={minDate ? toMonth(minDate) : undefined}
+      className={cn("select-none", className)}
+      classNames={getCalendarClassNames({ classNames, defaultClassNames })}
+    />
+  );
+}

--- a/src/shared/components/calendar/use-calendar-selection.ts
+++ b/src/shared/components/calendar/use-calendar-selection.ts
@@ -1,0 +1,218 @@
+import { isSameDay } from "date-fns";
+import {
+  type MouseEvent as ReactMouseEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { DayEventHandler, OnSelectHandler } from "react-day-picker";
+import {
+  type DragSelectionMode,
+  getCalendarDateKey,
+  getCalendarDayMeta,
+  getDraggedSelection,
+  isBlockedDay,
+} from "./drag-selection-utils";
+
+type UseCalendarSelectionParams = {
+  calendarId: string;
+  defaultSelected?: Date[];
+  enableDragSelection: boolean;
+  onDayMouseEnter?: DayEventHandler<ReactMouseEvent>;
+  onSelect?: (dates: Date[]) => void;
+  selected?: Date[];
+};
+
+export type UseCalendarSelectionResult = {
+  handleDayMouseEnter: DayEventHandler<ReactMouseEvent>;
+  handleSelect: OnSelectHandler<Date[] | undefined>;
+  selectedDates: Date[];
+};
+
+function getSortedUniqueDates(dates: Date[]) {
+  const dateMap = new Map<string, Date>();
+
+  for (const date of dates) {
+    dateMap.set(getCalendarDateKey(date), date);
+  }
+
+  return [...dateMap.values()].sort((a, b) => a.getTime() - b.getTime());
+}
+
+function isSameDateList(a: Date[], b: Date[]) {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((date, index) => {
+    const nextDate = b[index];
+    return nextDate ? isSameDay(date, nextDate) : false;
+  });
+}
+
+export function useCalendarSelection({
+  calendarId,
+  defaultSelected,
+  enableDragSelection,
+  onDayMouseEnter,
+  onSelect,
+  selected,
+}: UseCalendarSelectionParams): UseCalendarSelectionResult {
+  const isControlled = selected !== undefined;
+  const [internalSelected, setInternalSelected] = useState<Date[]>(() =>
+    getSortedUniqueDates(defaultSelected ?? []),
+  );
+
+  // 드래그 선택(add/remove) 진행 상태를 ref로 관리한다.
+  // 빈번한 마우스 이벤트마다 렌더링이 발생하지 않도록 state 대신 ref를 사용한다.
+  const dragStartDateRef = useRef<Date | null>(null);
+  const dragBaseDatesRef = useRef<Date[]>([]);
+  const dragModeRef = useRef<DragSelectionMode>("add");
+  const dragCommittedRef = useRef(false);
+  const isMouseDownRef = useRef(false);
+
+  // 드래그 종료 직후 click 이벤트가 한 번 더 들어와 토글되는 것을 막기 위한 guard.
+  const suppressClickDayKeyRef = useRef<string | null>(null);
+  const suppressClickUntilMsRef = useRef(0);
+
+  const selectedDates = useMemo(
+    () =>
+      getSortedUniqueDates((isControlled ? selected : internalSelected) ?? []),
+    [internalSelected, isControlled, selected],
+  );
+  const selectedDatesRef = useRef<Date[]>(selectedDates);
+
+  // 이벤트 핸들러에서 최신 선택 상태를 즉시 참조할 수 있도록 동기화한다.
+  useEffect(() => {
+    selectedDatesRef.current = selectedDates;
+  }, [selectedDates]);
+
+  useEffect(() => {
+    // drag 시작점/모드(add|remove)는 mousedown 시점에 결정한다.
+    function handleMouseDown(event: MouseEvent) {
+      if (!enableDragSelection || event.button !== 0) {
+        return;
+      }
+
+      if (suppressClickUntilMsRef.current <= Date.now()) {
+        suppressClickDayKeyRef.current = null;
+        suppressClickUntilMsRef.current = 0;
+      }
+
+      const dayMeta = getCalendarDayMeta(calendarId, event.target);
+
+      if (!dayMeta || dayMeta.isBlocked) {
+        return;
+      }
+
+      dragCommittedRef.current = false;
+      dragStartDateRef.current = dayMeta.date;
+      dragBaseDatesRef.current = selectedDatesRef.current;
+      dragModeRef.current = dayMeta.isSelected ? "remove" : "add";
+      isMouseDownRef.current = true;
+    }
+
+    // drag가 실제로 반영되었다면 mouseup 직후 click 토글을 일시적으로 무시한다.
+    function handleMouseUp() {
+      if (dragCommittedRef.current && dragStartDateRef.current) {
+        suppressClickDayKeyRef.current = getCalendarDateKey(
+          dragStartDateRef.current,
+        );
+        suppressClickUntilMsRef.current = Date.now() + 250;
+      }
+
+      dragCommittedRef.current = false;
+      dragStartDateRef.current = null;
+      dragBaseDatesRef.current = [];
+      dragModeRef.current = "add";
+      isMouseDownRef.current = false;
+    }
+
+    window.addEventListener("mousedown", handleMouseDown, true);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousedown", handleMouseDown, true);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [calendarId, enableDragSelection]);
+
+  // 선택 배열을 정규화(중복 제거/정렬)하고 controlled/uncontrolled 상태를 동시에 처리한다.
+  function applySelection(nextDates: Date[]) {
+    const normalizedDates = getSortedUniqueDates(nextDates);
+
+    if (isSameDateList(selectedDatesRef.current, normalizedDates)) {
+      return;
+    }
+
+    selectedDatesRef.current = normalizedDates;
+
+    if (!isControlled) {
+      setInternalSelected(normalizedDates);
+    }
+
+    onSelect?.(normalizedDates);
+  }
+
+  // DayPicker 기본 multiple 선택 결과를 받는다.
+  // 단, drag 직후 발생한 click 토글은 guard 조건에서 무시한다.
+  const handleSelect: OnSelectHandler<Date[] | undefined> = (
+    nextDates,
+    triggerDate,
+    _modifiers,
+    event,
+  ) => {
+    if (
+      suppressClickDayKeyRef.current === getCalendarDateKey(triggerDate) &&
+      suppressClickUntilMsRef.current > Date.now() &&
+      event instanceof MouseEvent
+    ) {
+      suppressClickDayKeyRef.current = null;
+      suppressClickUntilMsRef.current = 0;
+      return;
+    }
+
+    applySelection(nextDates ?? []);
+  };
+
+  // drag 중 포인터가 다른 날짜로 진입하면 baseDates + range 계산으로 선택을 갱신한다.
+  const handleDayMouseEnter: DayEventHandler<ReactMouseEvent> = (
+    day,
+    modifiers,
+    event,
+  ) => {
+    onDayMouseEnter?.(day, modifiers, event);
+
+    const dragStartDate = dragStartDateRef.current;
+
+    if (
+      !enableDragSelection ||
+      !isMouseDownRef.current ||
+      !dragStartDate ||
+      isBlockedDay(modifiers)
+    ) {
+      return;
+    }
+
+    if (isSameDay(day, dragStartDate)) {
+      return;
+    }
+
+    const nextDates = getDraggedSelection(
+      dragBaseDatesRef.current,
+      dragStartDate,
+      day,
+      dragModeRef.current,
+    );
+
+    dragCommittedRef.current = true;
+    applySelection(nextDates);
+  };
+
+  return {
+    handleDayMouseEnter,
+    handleSelect,
+    selectedDates,
+  };
+}


### PR DESCRIPTION
## Summary

- 달력 컴포넌트를 구현했습니다. 드래그를 통해 연속된 날짜들을 한 번에 선택하고 해제할 수 있도록 구현했습니다.

## Screenshots

| calendar | calendar |
| - | - |
| <img width="842" height="650" alt="CleanShot 2026-02-15 at 00 28 22@2x" src="https://github.com/user-attachments/assets/144e9841-49f3-49f9-ae03-e972f130a8da" />  | <img width="828" height="746" alt="CleanShot 2026-02-15 at 00 28 47@2x" src="https://github.com/user-attachments/assets/a213ec0a-30f6-46ba-bcc3-faa0907a0468" /> |

https://github.com/user-attachments/assets/4a25b12e-56c8-443c-8414-950d4f6bcec7

## References

- closes #36

## Stacks

<!-- ejoffe/spr start -->
commit-id:5278011d

---

**Stack**:
- #60
- #57 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
