### PR TITLE
feat: Chip 디자인 시스템 구현

### DIFF
--- a/src/shared/components/chip/index.stories.tsx
+++ b/src/shared/components/chip/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Chip } from "@/shared/components/chip";
+
+const meta = {
+  title: "shared/Chip",
+  component: Chip,
+  args: { children: "text", size: "md" },
+  argTypes: {
+    size: {
+      control: "inline-radio",
+      options: ["sm", "md"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] px-5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const OverflowSchedulesChip: Story = {
+  args: {
+    children: "+n",
+    size: "sm",
+  },
+};
+
+export const SizeVariants: Story = {
+  render: () => (
+    <div className="flex w-full items-end gap-3">
+      <Chip size="sm">+n</Chip>
+      <Chip size="md">text</Chip>
+    </div>
+  ),
+};

--- a/src/shared/components/chip/index.tsx
+++ b/src/shared/components/chip/index.tsx
@@ -1,0 +1,30 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { HTMLAttributes } from "react";
+import { cn } from "@/shared/utils/cn";
+
+export const chipVariants = cva(
+  "inline-flex w-fit shrink-0 select-none items-center justify-center whitespace-nowrap bg-k-50",
+  {
+    variants: {
+      size: {
+        sm: "rounded-sm px-1 py-px text-c2 text-k-600",
+        md: "rounded-md px-3 py-1.5 text-b4 text-k-700",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  },
+);
+
+export interface ChipProps
+  extends HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof chipVariants> {}
+
+export function Chip({ children, className, size, ...props }: ChipProps) {
+  return (
+    <span className={cn(chipVariants({ size }), className)} {...props}>
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Chip 컴포넌트를 구현했습니다.

## Screenshots

<img width="686" height="442" alt="CleanShot 2026-02-15 at 00 34 43@2x" src="https://github.com/user-attachments/assets/0c0fccf6-258e-4525-a219-b82f76ba2f45" />

## References

- closes #39

## Stacks

<!-- ejoffe/spr start -->
commit-id:fc9872d5

---

**Stack**:
- #60
- #57
- #52
- #50
- #59
- #47
- #58 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
