### PR TITLE
feat: Toast 디자인 시스템 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "date-fns": "^4.1.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -2325,6 +2328,12 @@ packages:
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
@@ -4665,6 +4674,11 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   sort-object-keys@2.1.0: {}
 

--- a/src/shared/components/toast/index.stories.tsx
+++ b/src/shared/components/toast/index.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ButtonBottom } from "@/shared/components/button-bottom";
+import { ChipButton } from "@/shared/components/chip-button";
+import { IconButton } from "@/shared/components/icon-button";
+import { ShareIcon } from "@/shared/components/icons";
+import { Toast, toast } from "@/shared/components/toast";
+
+const DEFAULT_TOASTER_ID = "storybook-toast";
+
+const meta = {
+  title: "shared/Toast",
+  component: Toast,
+  args: {
+    closeButton: false,
+    duration: 2000,
+    id: DEFAULT_TOASTER_ID,
+    position: "bottom-center",
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto h-dvh w-[375px] px-5">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => {
+    const toasterId = args.id ?? DEFAULT_TOASTER_ID;
+
+    return (
+      <div className="relative h-full w-full">
+        <Toast {...args} />
+
+        <div className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-2">
+          <ChipButton
+            size="lg"
+            variant="primary"
+            onClick={() => toast.success("완료되었어요", { toasterId })}
+          >
+            완료
+          </ChipButton>
+          <ChipButton
+            size="lg"
+            variant="outlined"
+            onClick={() => toast.error("다시 시도해 주세요", { toasterId })}
+          >
+            오류
+          </ChipButton>
+        </div>
+
+        <div className="absolute inset-x-0 bottom-0 flex items-center gap-2 px-5 py-3">
+          <ShareIconButton />
+          <ButtonBottom className="w-full flex-1" variant="black">
+            일정 수정하기
+          </ButtonBottom>
+        </div>
+      </div>
+    );
+  },
+};
+
+const ShareIconButton = () => {
+  return (
+    <IconButton
+      icon={ShareIcon}
+      size="2xl"
+      background="square"
+      backgroundSize="lg"
+      iconSize="xl"
+      variant="dark"
+    />
+  );
+};

--- a/src/shared/components/toast/index.tsx
+++ b/src/shared/components/toast/index.tsx
@@ -1,0 +1,64 @@
+import type { CSSProperties } from "react";
+import {
+  Toaster as Sonner,
+  toast as sonnerToast,
+  type ToasterProps,
+} from "sonner";
+import { CheckIcon, ErrorIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+
+export const toast = {
+  success: sonnerToast.success,
+  dismiss: sonnerToast.dismiss,
+  error: sonnerToast.error,
+};
+
+const TOAST_BOTTOM_OFFSET = 90; // 78px (button-bottom container height) + 12px (padding)
+
+export interface ToastProps extends ToasterProps {}
+
+export function Toast({
+  className,
+  style,
+  toastOptions,
+  ...props
+}: ToastProps) {
+  return (
+    <Sonner
+      {...props}
+      icons={{
+        error: <ErrorIcon className="size-5 shrink-0 text-action-red" />,
+        success: <CheckIcon className="size-5 shrink-0 text-action-green" />,
+      }}
+      gap={4}
+      offset={{ bottom: TOAST_BOTTOM_OFFSET }}
+      style={
+        {
+          "--border-radius": "calc(infinity * 1px)",
+          "--normal-bg": "var(--color-k700)",
+          "--normal-border": "transparent",
+          "--normal-text": "var(--color-k5)",
+          ...style,
+        } as CSSProperties
+      }
+      toastOptions={{
+        ...toastOptions,
+        classNames: {
+          ...toastOptions?.classNames,
+          closeButton: cn(
+            "border-none bg-k-750 text-k-300 transition-colors hover:bg-k-800 hover:text-k-100",
+            toastOptions?.classNames?.closeButton,
+          ),
+          content: cn("items-center gap-1", toastOptions?.classNames?.content),
+          icon: cn("size-5 shrink-0", toastOptions?.classNames?.icon),
+          toast: cn(
+            "cn-toast inline-flex! items-center! w-fit! gap-0.5! rounded-full! px-4! py-2! text-b4! text-k-5! shadow-none! data-[x-position=center]:right-0 data-[x-position=center]:left-0 data-[x-position=center]:mx-auto",
+            toastOptions?.classNames?.toast,
+          ),
+          title: cn("text-b4 text-k-5", toastOptions?.classNames?.title),
+        },
+      }}
+      className={cn("group toaster", className)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Toast 디자인 시스템을 구현했습니다.
- 위치는 동적으로 지정할 수 있는데 (ex. `bottom-left`, `bottom-center` 등) offset은 동적으로 지정할 수 없어서 현재는 고정적으로 offset을 지정해야 하는 구조입니다. (`offset={{ bottom: 90 }}`)

## Screenshots

| complete | error |
| - | - |
| <img width="350" height="176" alt="CleanShot 2026-02-15 at 00 37 12@2x" src="https://github.com/user-attachments/assets/14bc2519-5cf7-49d0-ad56-f32ec96d5adc" />  | <img width="400" height="158" alt="CleanShot 2026-02-15 at 00 37 15@2x" src="https://github.com/user-attachments/assets/12b73b93-afb6-4e1c-8953-95487da90ccd" />  |

https://github.com/user-attachments/assets/c2ea34b3-f8a5-4b0a-8607-b8e213a7a3ec

## References

- closes #39

## Stacks

<!-- ejoffe/spr start -->
commit-id:993be931

---

**Stack**:
- #60
- #57
- #52
- #50
- #59 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new toast notification system for displaying success and error messages to users with customizable positioning and duration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->