### PR TITLE
feat: ScheduleEdit 디자인 시스템 구현

### DIFF
--- a/src/domains/schedule/components/schedule-edit/date-summary.ts
+++ b/src/domains/schedule/components/schedule-edit/date-summary.ts
@@ -1,0 +1,62 @@
+import { differenceInCalendarDays, format } from "date-fns";
+
+export type ScheduleDateSummary = {
+  label: string;
+  overflow: number;
+};
+
+function formatDate(date: Date) {
+  return format(date, "M.d");
+}
+
+function getSortedUniqueDates(dates: Date[]) {
+  const uniqueDates = new Map<string, Date>();
+  for (const date of dates) {
+    uniqueDates.set(format(date, "yyyy-MM-dd"), date);
+  }
+
+  return [...uniqueDates.values()].sort((a, b) => a.getTime() - b.getTime());
+}
+
+function getConsecutiveDates(dates: Date[]) {
+  let consecutiveEndIndex = 0;
+  for (let index = 1; index < dates.length; index += 1) {
+    const previousDate = dates[index - 1];
+    const currentDate = dates[index];
+
+    if (differenceInCalendarDays(currentDate, previousDate) === 1) {
+      consecutiveEndIndex = index;
+    } else {
+      break;
+    }
+  }
+
+  return dates.slice(0, consecutiveEndIndex + 1);
+}
+
+export function getScheduleDateSummary(dates: Date[]): ScheduleDateSummary {
+  const sortedDates = getSortedUniqueDates(dates);
+  if (sortedDates.length === 0) {
+    return { label: "-", overflow: 0 };
+  }
+
+  if (sortedDates.length === 1) {
+    return { label: formatDate(sortedDates[0]), overflow: 0 };
+  }
+
+  const consecutiveDates = getConsecutiveDates(sortedDates);
+  if (consecutiveDates.length > 1) {
+    const from = formatDate(consecutiveDates[0]);
+    const to = formatDate(consecutiveDates[consecutiveDates.length - 1]);
+    return {
+      label: `${from} - ${to}`,
+      overflow: sortedDates.length - consecutiveDates.length,
+    };
+  }
+
+  const previewCount = Math.min(sortedDates.length, 2);
+  return {
+    label: sortedDates.slice(0, previewCount).map(formatDate).join(", "),
+    overflow: sortedDates.length - previewCount,
+  };
+}

--- a/src/domains/schedule/components/schedule-edit/index.stories.tsx
+++ b/src/domains/schedule/components/schedule-edit/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ScheduleEdit } from "@/domains/schedule/components/schedule-edit";
+
+const toDates = (days: number[]) => days.map((day) => new Date(2026, 11, day));
+
+const meta = {
+  title: "domains/schedule/ScheduleEdit",
+  component: ScheduleEdit,
+  args: {
+    dates: toDates([24, 25, 26, 27, 28]),
+    endTime: "24:30",
+    startTime: "22:30",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[375px] px-5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof ScheduleEdit>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NonConsecutiveWithOverflow: Story = {
+  args: {
+    dates: toDates([24, 26, 28, 30]),
+  },
+};
+
+export const ConsecutiveWithOverflow: Story = {
+  args: {
+    dates: toDates([24, 25, 26, 28, 30]),
+  },
+};
+
+export const SingleDate: Story = {
+  args: {
+    dates: toDates([24]),
+  },
+};

--- a/src/domains/schedule/components/schedule-edit/index.tsx
+++ b/src/domains/schedule/components/schedule-edit/index.tsx
@@ -1,0 +1,82 @@
+import { type HTMLAttributes, type ReactNode, useMemo } from "react";
+import { Chip } from "@/shared/components/chip";
+import {
+  ChipButton,
+  type ChipButtonProps,
+} from "@/shared/components/chip-button";
+import { CalendarIcon, TimeIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+import { getScheduleDateSummary } from "./date-summary";
+
+export interface ScheduleEditProps extends HTMLAttributes<HTMLDivElement> {
+  dates: Date[];
+  endTime: string;
+  startTime: string;
+  editButtonProps?: Omit<
+    ChipButtonProps,
+    "children" | "size" | "variant" | "onClick"
+  >;
+  editLabel?: ReactNode;
+  onEdit?: () => void;
+}
+
+export function ScheduleEdit({
+  className,
+  dates,
+  editButtonProps,
+  editLabel = "수정",
+  endTime,
+  startTime,
+  onEdit,
+  ...props
+}: ScheduleEditProps) {
+  const {
+    className: editButtonClassName,
+    type,
+    ...restEditButtonProps
+  } = editButtonProps ?? {};
+
+  const { label: dateLabel, overflow } = useMemo(
+    () => getScheduleDateSummary(dates),
+    [dates],
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center justify-between rounded-lg border border-k-100 bg-k-5 px-3 py-2",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex min-w-0 items-center gap-2 text-b4">
+        <div className="flex items-center gap-1.5">
+          <span className="inline-flex shrink-0 items-center gap-0.5 whitespace-nowrap">
+            <CalendarIcon
+              aria-hidden
+              className="size-5 shrink-0 translate-y-[0.5px] text-k-500"
+            />
+            <span className="text-k-900">{dateLabel}</span>
+          </span>
+          {overflow > 0 ? <Chip size="sm">+{overflow}</Chip> : null}
+        </div>
+        <span className="inline-flex shrink-0 items-center gap-0.5 whitespace-nowrap">
+          <TimeIcon aria-hidden className="size-5 shrink-0 text-k-500" />
+          <span className="text-k-900">
+            {startTime} - {endTime}
+          </span>
+        </span>
+      </div>
+      <ChipButton
+        size="sm"
+        type={type ?? "button"}
+        variant="primary"
+        className={editButtonClassName}
+        onClick={onEdit}
+        {...restEditButtonProps}
+      >
+        {editLabel}
+      </ChipButton>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- ScheduleEdit 컴포넌트를 구현했습니다.

## Screenshots

| default | overflow |
| - | - |
| <img width="764" height="158" alt="CleanShot 2026-02-15 at 00 44 38@2x" src="https://github.com/user-attachments/assets/fc34289b-0fb2-4ec4-8dc6-0f72454a02f0" /> | <img width="772" height="158" alt="CleanShot 2026-02-15 at 00 44 42@2x" src="https://github.com/user-attachments/assets/8b98059e-2035-4369-9894-00c682b7ee16" /> |
| | <img width="786" height="166" alt="CleanShot 2026-02-15 at 00 44 30@2x" src="https://github.com/user-attachments/assets/070bc75c-52b4-4d2f-bb0d-980f235d83ec" /> |

## References

- closes #38

## Stacks

<!-- ejoffe/spr start -->
commit-id:2e14c9f5

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schedule editor component that displays dates in a compact format with an overflow indicator for additional dates, shows the associated start and end times with visual icons, and includes an edit button for modifying schedule details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->