### PR TITLE
feat: ToastProvider 추가

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { CustomRoutes } from "@/routes";
 import { ReactRouterProvider } from "@/shared/providers/react-router-provider";
 import { TanstackQueryProvider } from "@/shared/providers/tanstack-query-provider";
+import { ToastProvider } from "@/shared/providers/toast-provider";
 
 const rootElement = document.getElementById("root");
 if (rootElement) {
@@ -11,7 +12,9 @@ if (rootElement) {
     <StrictMode>
       <TanstackQueryProvider>
         <ReactRouterProvider>
-          <CustomRoutes />
+          <ToastProvider>
+            <CustomRoutes />
+          </ToastProvider>
         </ReactRouterProvider>
       </TanstackQueryProvider>
     </StrictMode>,

--- a/src/shared/providers/toast-provider/index.tsx
+++ b/src/shared/providers/toast-provider/index.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from "react";
+import { Toast } from "@/shared/components/toast";
+
+export function ToastProvider({ children }: PropsWithChildren) {
+  return (
+    <>
+      {children}
+      <Toast position="bottom-center" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Toast를 사용했을 때 화면에 렌더링 될 수 있도록 ToastProvider를 추가했습니다.
- 편의상 Provider의 형태로 구현했지만, DOM 트리 내에 존재만 하면 Context 같은 것이 없어도 잘 동작합니다.

## References

- ref #41

## Stacks

<!-- ejoffe/spr start -->
commit-id:eae5c593

---

**Stack**:
- #96
- #90
- #89
- #86
- #88
- #87 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toast notification system to the application. Toast notifications are now globally available and positioned at the bottom-center of the screen, enabling the app to display user feedback messages throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->