### PR TITLE
feat: Timetable 컴포넌트 수정 (스크롤 헤더 고정, 모바일 드래그 등)

### DIFF
--- a/src/shared/components/timetable-slot/index.tsx
+++ b/src/shared/components/timetable-slot/index.tsx
@@ -1,3 +1,4 @@
+import type { PointerEvent } from "react";
 import { cn } from "@/shared/utils/cn";
 
 export interface TimetableSlotProps {
@@ -5,9 +6,10 @@ export interface TimetableSlotProps {
   isDisabled?: boolean;
   opacity?: number;
   onClick?: () => void;
-  onMouseDown?: () => void;
-  onMouseEnter?: () => void;
+  onPointerDown?: (event: PointerEvent<HTMLButtonElement>) => void;
   className?: string;
+  dataDateIdx?: number;
+  dataSlotIdx?: number;
 }
 
 export function TimetableSlot({
@@ -15,17 +17,19 @@ export function TimetableSlot({
   isDisabled,
   opacity = 0,
   onClick,
-  onMouseDown,
-  onMouseEnter,
+  onPointerDown,
   className,
+  dataDateIdx,
+  dataSlotIdx,
 }: TimetableSlotProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      onMouseDown={onMouseDown}
-      onMouseEnter={onMouseEnter}
+      onPointerDown={onPointerDown}
       disabled={isDisabled}
+      data-date-idx={dataDateIdx}
+      data-slot-idx={dataSlotIdx}
       className={cn(
         "h-10 w-full rounded-md border transition-all",
         "border-k-50 bg-k-10",

--- a/src/shared/components/timetable/index.stories.tsx
+++ b/src/shared/components/timetable/index.stories.tsx
@@ -72,8 +72,8 @@ export const Interactive: Story = {
   },
   args: {
     startTime: 9,
-    endTime: 15,
-    dates: getDates(3),
+    endTime: 23,
+    dates: getDates(8),
   },
 };
 

--- a/src/shared/components/timetable/index.tsx
+++ b/src/shared/components/timetable/index.tsx
@@ -1,4 +1,12 @@
-import React, { useMemo } from "react";
+import {
+  Fragment,
+  type PointerEvent as ReactPointerEvent,
+  type UIEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { TimetableSlot } from "@/shared/components/timetable-slot";
 import { cn } from "@/shared/utils/cn";
 import { useTimetableDragSelection } from "./use-timetable-drag-selection";
@@ -12,6 +20,7 @@ export interface TimetableProps {
   onSelect?: (dates: Date[]) => void;
   disabled?: boolean;
   occupancy?: Record<string, number>;
+  stickyHeaderTop?: number;
 }
 
 const getOpacityMap = (occupancy: Record<string, number>) => {
@@ -38,18 +47,28 @@ export function Timetable({
   onSelect,
   disabled = false,
   occupancy = {},
+  stickyHeaderTop = 0,
 }: TimetableProps) {
   const totalSlots = (endTime - startTime) * 2;
 
-  const { selectedSlots, handleMouseDown, handleMouseEnter } =
-    useTimetableDragSelection({
-      dates,
-      startTime,
-      selected,
-      onSelect,
-    });
+  const {
+    selectedSlots,
+    isDraggingSelection,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  } = useTimetableDragSelection({
+    dates,
+    startTime,
+    selected,
+    onSelect,
+  });
 
   const opacityMap = useMemo(() => getOpacityMap(occupancy), [occupancy]);
+  const headerTrackRef = useRef<HTMLDivElement>(null);
+  const bodyScrollRef = useRef<HTMLDivElement>(null);
+  const frameIdRef = useRef<number | null>(null);
+  const pendingScrollLeftRef = useRef(0);
 
   const getDayName = (date: Date) => {
     return new Intl.DateTimeFormat("ko-KR", { weekday: "short" }).format(date);
@@ -61,81 +80,261 @@ export function Timetable({
     return `${mm}.${dd}`;
   };
 
-  const gridTemplateColumns = useMemo(() => {
+  const bodyGridTemplateColumns = useMemo(() => {
     if (dates.length <= 4) {
       return `20px repeat(${dates.length}, 1fr)`;
     }
     return `20px repeat(${dates.length}, 62px)`;
   }, [dates.length]);
 
+  const headerGridTemplateColumns = useMemo(() => {
+    if (dates.length <= 4) {
+      return `repeat(${dates.length}, minmax(0, 1fr))`;
+    }
+    return `repeat(${dates.length}, 62px)`;
+  }, [dates.length]);
+
+  const syncHeaderTrack = useCallback(() => {
+    if (!headerTrackRef.current) {
+      frameIdRef.current = null;
+      return;
+    }
+
+    headerTrackRef.current.style.transform = `translate3d(${-pendingScrollLeftRef.current}px, 0, 0)`;
+    frameIdRef.current = null;
+  }, []);
+
+  const handleBodyScroll = (event: UIEvent<HTMLDivElement>) => {
+    pendingScrollLeftRef.current = event.currentTarget.scrollLeft;
+
+    if (frameIdRef.current !== null) {
+      return;
+    }
+
+    frameIdRef.current = window.requestAnimationFrame(syncHeaderTrack);
+  };
+
+  const getSlotPosFromPoint = (
+    container: HTMLDivElement,
+    clientX: number,
+    clientY: number,
+  ) => {
+    const target = document.elementFromPoint(
+      clientX,
+      clientY,
+    ) as HTMLElement | null;
+
+    if (!target || !container.contains(target)) {
+      return null;
+    }
+
+    const slotElement = target.closest<HTMLElement>(
+      "[data-date-idx][data-slot-idx]",
+    );
+    if (!slotElement) {
+      return null;
+    }
+
+    const dateIdx = Number(slotElement.dataset.dateIdx);
+    const slotIdx = Number(slotElement.dataset.slotIdx);
+
+    if (Number.isNaN(dateIdx) || Number.isNaN(slotIdx)) {
+      return null;
+    }
+
+    return { dateIdx, slotIdx };
+  };
+
+  const handleBodyPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (disabled) {
+      return;
+    }
+
+    const pos = getSlotPosFromPoint(
+      event.currentTarget,
+      event.clientX,
+      event.clientY,
+    );
+
+    const shouldPreventScroll = handlePointerMove({
+      pointerId: event.pointerId,
+      pointerType: event.pointerType,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      pos,
+    });
+
+    if (shouldPreventScroll) {
+      event.preventDefault();
+    }
+  };
+
+  const handleBodyPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (disabled) {
+      return;
+    }
+
+    handlePointerUp(event.pointerId);
+  };
+
+  useEffect(() => {
+    const bodyElement = bodyScrollRef.current;
+
+    if (!bodyElement) {
+      return;
+    }
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (!isDraggingSelection) {
+        return;
+      }
+
+      event.preventDefault();
+    };
+
+    bodyElement.addEventListener("touchmove", handleTouchMove, {
+      passive: false,
+    });
+
+    return () => {
+      bodyElement.removeEventListener("touchmove", handleTouchMove);
+    };
+  }, [isDraggingSelection]);
+
+  useEffect(() => {
+    return () => {
+      if (frameIdRef.current !== null) {
+        window.cancelAnimationFrame(frameIdRef.current);
+      }
+    };
+  }, []);
+
   return (
-    <div
-      className={cn("relative w-full select-none overflow-x-auto", className)}
-    >
-      <div
-        className="mb-3 grid min-w-max gap-1"
-        style={{ gridTemplateColumns }}
-      >
-        <div className="sticky top-0 left-0 z-20 -mr-1 h-[58px] w-5 bg-k-5" />
-        {dates.map((date) => (
+    <div className={cn("relative w-full select-none", className)}>
+      <div className="sticky z-10 bg-k-5" style={{ top: stickyHeaderTop }}>
+        <div className="flex gap-1 pb-3">
+          <div className="sticky left-0 z-10 h-[58px] w-5 shrink-0 bg-k-5" />
+
           <div
-            key={date.toISOString()}
-            className="sticky top-0 z-20 flex h-[54px] flex-col items-center justify-center bg-k-5"
+            className="min-w-0 flex-1 overflow-hidden"
+            data-timetable-scroll="header"
           >
-            <span className="text-b3 text-k-500">{getDayName(date)}</span>
-            <span className="text-b3 text-k-700">{getFormattedDate(date)}</span>
+            <div
+              ref={headerTrackRef}
+              className={cn(
+                "grid gap-1 will-change-transform",
+                dates.length > 4 && "min-w-max",
+              )}
+              style={{ gridTemplateColumns: headerGridTemplateColumns }}
+            >
+              {dates.map((date) => (
+                <div
+                  key={`header-${date.toISOString()}`}
+                  className="flex h-[54px] flex-col items-center justify-center bg-k-5"
+                >
+                  <span className="text-b3 text-k-500">{getDayName(date)}</span>
+                  <span className="text-b3 text-k-700">
+                    {getFormattedDate(date)}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
-        ))}
+        </div>
+      </div>
 
-        {Array.from({ length: totalSlots }).map((_, slotIdx) => {
-          const isHourStart = slotIdx % 2 === 0;
-          const currentHour = startTime + Math.floor(slotIdx / 2);
-          const currentMinutes = slotIdx % 2 !== 0 ? 30 : 0;
-          const isLastSlot = slotIdx === totalSlots - 1;
+      <div
+        ref={bodyScrollRef}
+        onScroll={handleBodyScroll}
+        onPointerMove={handleBodyPointerMove}
+        onPointerUp={handleBodyPointerUp}
+        onPointerCancel={handleBodyPointerUp}
+        className={cn(
+          "overflow-x-auto overflow-y-hidden overscroll-x-contain",
+          isDraggingSelection ? "touch-none" : "touch-auto",
+        )}
+        data-timetable-scroll="body"
+      >
+        <div
+          className="grid min-w-max gap-1"
+          style={{ gridTemplateColumns: bodyGridTemplateColumns }}
+        >
+          {Array.from({ length: totalSlots }).map((_, slotIdx) => {
+            const isHourStart = slotIdx % 2 === 0;
+            const currentHour = startTime + Math.floor(slotIdx / 2);
+            const currentMinutes = slotIdx % 2 !== 0 ? 30 : 0;
+            const isFirstSlot = slotIdx === 0;
+            const isLastSlot = slotIdx === totalSlots - 1;
 
-          return (
-            <React.Fragment key={`row-${currentHour}-${currentMinutes}}`}>
-              <div className="sticky left-0 z-20 -mr-2 h-[40px] w-5 bg-k-5">
-                {isHourStart && (
-                  <span className="absolute -top-2.5 left-0 z-30 w-full text-b3 text-k-500">
-                    {String(currentHour)}
-                  </span>
-                )}
+            return (
+              <Fragment key={`row-${currentHour}-${currentMinutes}`}>
+                <div className="sticky left-0 z-20 -mr-2 h-[40px] w-5 bg-k-5">
+                  {isHourStart && (
+                    <span
+                      className={cn(
+                        "absolute left-0 z-20 w-full bg-k-5 text-b3 text-k-500",
+                        isFirstSlot ? "top-0" : "-top-2.5",
+                      )}
+                    >
+                      {String(currentHour)}
+                    </span>
+                  )}
 
-                {isLastSlot && (
-                  <span className="absolute -bottom-2.5 left-0 z-30 w-full text-b3 text-k-500">
-                    {String(endTime)}
-                  </span>
-                )}
-              </div>
+                  {isLastSlot && (
+                    <span className="absolute bottom-0 left-0 z-20 w-full bg-k-5 text-b3 text-k-500">
+                      {String(endTime)}
+                    </span>
+                  )}
+                </div>
 
-              {dates.map((date, dateIdx) => {
-                const slotDate = new Date(date);
-                slotDate.setHours(currentHour, currentMinutes, 0, 0);
-                const timeKey = slotDate.getTime().toString();
+                {dates.map((date, dateIdx) => {
+                  const slotDate = new Date(date);
+                  slotDate.setHours(currentHour, currentMinutes, 0, 0);
+                  const timeKey = slotDate.getTime().toString();
 
-                const isSelected = selectedSlots.has(timeKey);
-                const userCount = occupancy[timeKey] || 0;
-                const opacity = opacityMap[userCount] || 0;
-                return (
-                  <TimetableSlot
-                    key={timeKey}
-                    isSelected={isSelected}
-                    isDisabled={disabled}
-                    opacity={opacity}
-                    onMouseDown={() =>
-                      !disabled && handleMouseDown(dateIdx, slotIdx)
-                    }
-                    onMouseEnter={() =>
-                      !disabled && handleMouseEnter(dateIdx, slotIdx)
-                    }
-                    className={cn("touch-none", disabled && "cursor-default")}
-                  />
-                );
-              })}
-            </React.Fragment>
-          );
-        })}
+                  const isSelected = selectedSlots.has(timeKey);
+                  const userCount = occupancy[timeKey] || 0;
+                  const opacity = opacityMap[userCount] || 0;
+
+                  return (
+                    <TimetableSlot
+                      key={timeKey}
+                      isSelected={isSelected}
+                      isDisabled={disabled}
+                      opacity={opacity}
+                      dataDateIdx={dateIdx}
+                      dataSlotIdx={slotIdx}
+                      onPointerDown={(event) => {
+                        if (disabled) {
+                          return;
+                        }
+
+                        handlePointerDown({
+                          dateIdx,
+                          slotIdx,
+                          pointerId: event.pointerId,
+                          pointerType: event.pointerType,
+                          clientX: event.clientX,
+                          clientY: event.clientY,
+                        });
+
+                        if (event.pointerType === "touch") {
+                          event.currentTarget.setPointerCapture(
+                            event.pointerId,
+                          );
+                          return;
+                        }
+
+                        event.preventDefault();
+                      }}
+                      className={cn(disabled && "cursor-default")}
+                    />
+                  );
+                })}
+              </Fragment>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/shared/components/timetable/use-timetable-drag-selection.ts
+++ b/src/shared/components/timetable/use-timetable-drag-selection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type DragPos = { dateIdx: number; slotIdx: number };
 
@@ -8,6 +8,24 @@ interface UseTimetableDragSelectionParams {
   selected: Date[];
   onSelect?: (dates: Date[]) => void;
 }
+
+interface PointerDownParams extends DragPos {
+  pointerId: number;
+  pointerType: string;
+  clientX: number;
+  clientY: number;
+}
+
+interface PointerMoveParams {
+  pointerId: number;
+  pointerType: string;
+  clientX: number;
+  clientY: number;
+  pos: DragPos | null;
+}
+
+const TOUCH_MOVE_THRESHOLD = 8;
+const TOUCH_LONG_PRESS_MS = 100;
 
 export function useTimetableDragSelection({
   dates,
@@ -19,11 +37,26 @@ export function useTimetableDragSelection({
     return new Set(selected.map((date) => date.getTime().toString()));
   }, [selected]);
 
-  const isMouseDownRef = useRef(false);
+  const [isDraggingSelection, setIsDraggingSelection] = useState(false);
+
+  const isPointerDownRef = useRef(false);
+  const isSelectingRef = useRef(false);
+  const activePointerIdRef = useRef<number | null>(null);
+
   const dragStartPosRef = useRef<DragPos | null>(null);
   const dragModeRef = useRef<"add" | "remove">("add");
-
   const initialSelectedBeforeDragRef = useRef<Set<string>>(new Set());
+  const lastDragPosRef = useRef<DragPos | null>(null);
+
+  const startClientPosRef = useRef<{ x: number; y: number } | null>(null);
+  const longPressTimerRef = useRef<number | null>(null);
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
 
   const getSlotDate = useCallback(
     (dateIdx: number, slotIdx: number) => {
@@ -40,7 +73,9 @@ export function useTimetableDragSelection({
 
   const updateRangeSelection = useCallback(
     (currentPos: DragPos) => {
-      if (!dragStartPosRef.current || !onSelect) return;
+      if (!dragStartPosRef.current || !onSelect) {
+        return;
+      }
 
       const start = dragStartPosRef.current;
       const minDateIdx = Math.min(start.dateIdx, currentPos.dateIdx);
@@ -50,9 +85,9 @@ export function useTimetableDragSelection({
 
       const nextSelectedSet = new Set(initialSelectedBeforeDragRef.current);
 
-      for (let d = minDateIdx; d <= maxDateIdx; d++) {
-        for (let s = minSlotIdx; s <= maxSlotIdx; s++) {
-          const slotDate = getSlotDate(d, s);
+      for (let dateIdx = minDateIdx; dateIdx <= maxDateIdx; dateIdx += 1) {
+        for (let slotIdx = minSlotIdx; slotIdx <= maxSlotIdx; slotIdx += 1) {
+          const slotDate = getSlotDate(dateIdx, slotIdx);
           const timeStr = slotDate.getTime().toString();
 
           if (dragModeRef.current === "add") {
@@ -71,36 +106,162 @@ export function useTimetableDragSelection({
     [getSlotDate, onSelect],
   );
 
-  const handleMouseDown = (dateIdx: number, slotIdx: number) => {
-    const slotDate = getSlotDate(dateIdx, slotIdx);
-    const isSelected = selectedSlots.has(slotDate.getTime().toString());
+  const startSelection = useCallback(
+    (startPos: DragPos) => {
+      const slotDate = getSlotDate(startPos.dateIdx, startPos.slotIdx);
+      const isSelected = selectedSlots.has(slotDate.getTime().toString());
 
-    isMouseDownRef.current = true;
-    dragStartPosRef.current = { dateIdx, slotIdx };
-    dragModeRef.current = isSelected ? "remove" : "add";
+      dragStartPosRef.current = startPos;
+      dragModeRef.current = isSelected ? "remove" : "add";
+      initialSelectedBeforeDragRef.current = new Set(selectedSlots);
+      lastDragPosRef.current = null;
 
-    initialSelectedBeforeDragRef.current = new Set(selectedSlots);
+      isSelectingRef.current = true;
+      setIsDraggingSelection(true);
+      updateRangeSelection(startPos);
+    },
+    [getSlotDate, selectedSlots, updateRangeSelection],
+  );
 
-    updateRangeSelection({ dateIdx, slotIdx });
-  };
+  const finishInteraction = useCallback(
+    (pointerId?: number) => {
+      if (
+        pointerId !== undefined &&
+        activePointerIdRef.current !== null &&
+        activePointerIdRef.current !== pointerId
+      ) {
+        return;
+      }
 
-  const handleMouseEnter = (dateIdx: number, slotIdx: number) => {
-    if (!isMouseDownRef.current) return;
-    updateRangeSelection({ dateIdx, slotIdx });
-  };
+      clearLongPressTimer();
+      isPointerDownRef.current = false;
+      isSelectingRef.current = false;
+      activePointerIdRef.current = null;
+      dragStartPosRef.current = null;
+      startClientPosRef.current = null;
+      lastDragPosRef.current = null;
+
+      setIsDraggingSelection(false);
+    },
+    [clearLongPressTimer],
+  );
+
+  const handlePointerDown = useCallback(
+    ({
+      dateIdx,
+      slotIdx,
+      pointerId,
+      pointerType,
+      clientX,
+      clientY,
+    }: PointerDownParams) => {
+      if (!onSelect) {
+        return;
+      }
+
+      isPointerDownRef.current = true;
+      activePointerIdRef.current = pointerId;
+      startClientPosRef.current = { x: clientX, y: clientY };
+
+      if (pointerType === "touch") {
+        clearLongPressTimer();
+        longPressTimerRef.current = window.setTimeout(() => {
+          if (
+            !isPointerDownRef.current ||
+            activePointerIdRef.current !== pointerId
+          ) {
+            return;
+          }
+
+          startSelection({ dateIdx, slotIdx });
+        }, TOUCH_LONG_PRESS_MS);
+        return;
+      }
+
+      startSelection({ dateIdx, slotIdx });
+    },
+    [clearLongPressTimer, onSelect, startSelection],
+  );
+
+  const handlePointerMove = useCallback(
+    ({ pointerId, pointerType, clientX, clientY, pos }: PointerMoveParams) => {
+      if (
+        !isPointerDownRef.current ||
+        activePointerIdRef.current !== pointerId
+      ) {
+        return false;
+      }
+
+      if (pointerType === "touch" && !isSelectingRef.current) {
+        const startPos = startClientPosRef.current;
+        if (!startPos) {
+          return false;
+        }
+
+        const movedX = Math.abs(clientX - startPos.x);
+        const movedY = Math.abs(clientY - startPos.y);
+        const hasMovedFar =
+          movedX > TOUCH_MOVE_THRESHOLD || movedY > TOUCH_MOVE_THRESHOLD;
+
+        if (hasMovedFar) {
+          clearLongPressTimer();
+        }
+
+        return false;
+      }
+
+      if (!isSelectingRef.current) {
+        return false;
+      }
+
+      if (!pos) {
+        return true;
+      }
+
+      if (
+        lastDragPosRef.current?.dateIdx === pos.dateIdx &&
+        lastDragPosRef.current?.slotIdx === pos.slotIdx
+      ) {
+        return true;
+      }
+
+      lastDragPosRef.current = pos;
+      updateRangeSelection(pos);
+      return true;
+    },
+    [clearLongPressTimer, updateRangeSelection],
+  );
+
+  const handlePointerUp = useCallback(
+    (pointerId?: number) => {
+      finishInteraction(pointerId);
+    },
+    [finishInteraction],
+  );
 
   useEffect(() => {
-    const handleMouseUpGlobal = () => {
-      isMouseDownRef.current = false;
-      dragStartPosRef.current = null;
+    const handleWindowPointerUp = (event: PointerEvent) => {
+      finishInteraction(event.pointerId);
     };
-    window.addEventListener("mouseup", handleMouseUpGlobal);
-    return () => window.removeEventListener("mouseup", handleMouseUpGlobal);
-  }, []);
+
+    const handleWindowPointerCancel = (event: PointerEvent) => {
+      finishInteraction(event.pointerId);
+    };
+
+    window.addEventListener("pointerup", handleWindowPointerUp);
+    window.addEventListener("pointercancel", handleWindowPointerCancel);
+
+    return () => {
+      window.removeEventListener("pointerup", handleWindowPointerUp);
+      window.removeEventListener("pointercancel", handleWindowPointerCancel);
+    };
+  }, [finishInteraction]);
 
   return {
     selectedSlots,
-    handleMouseDown,
-    handleMouseEnter,
+    isDraggingSelection,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
   };
 }


### PR DESCRIPTION
## Summary

- Timetable 컴포넌트를 수정해서 스크롤 시에 왼쪽 및 상단의 헤더가 화면에 고정될 수 있도록 개선헀습니다.
- 모바일 환경에서는 바로 터치하여 이동하면 드래그, 약간 눌렀다가 (150ms) 이동하면 Cell이 드래그 선택이 될 수 있도록 수정했습니다.

## References

- closes #41

## Stacks

<!-- ejoffe/spr start -->
commit-id:17bb5431

---

**Stack**:
- #96
- #90
- #89
- #86
- #88 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timetable component now features a persistent sticky header that remains visible while scrolling through available time slots.
  * Enhanced drag selection to support multiple input types including touch, mouse, and pen interactions.

* **Updates**
  * Expanded demo timetable to display more dates (8 instead of 3) and extended time range (until 23:00 instead of 15:00).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->