### PR TITLE
feat: 일정 메인 화면 구현

### DIFF
--- a/src/assets/graphic/placeholder.svg
+++ b/src/assets/graphic/placeholder.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="currentColor" />
+</svg>

--- a/src/domains/schedule/components/card-recommended/index.stories.tsx
+++ b/src/domains/schedule/components/card-recommended/index.stories.tsx
@@ -20,17 +20,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    date: {
-      from: new Date(2024, 11, 25, 14, 0), // 2024년 12월 25일 14:00
-      to: new Date(2024, 11, 25, 16, 30), // 2024년 12월 25일 16:30
-    },
-    participants: [
-      { name: "김철수", isAvailable: true },
-      { name: "이영희", isAvailable: true },
-      { name: "박민수", isAvailable: false },
-      { name: "정소영", isAvailable: true },
-      { name: "최준호", isAvailable: false },
-    ],
+    scheduleDate: "2026-02-22",
+    scheduleDayOfWeek: "일요일",
+    startTime: "11:00",
+    endTime: "18:00",
+    voteCount: 3,
+    participantCount: 5,
+    availableParticipantNames: ["김수빈", "이영희", "정소영"],
+    unavailableParticipantNames: ["김철수", "최준호"],
   },
 };
 
@@ -41,6 +38,8 @@ export const Expanded: Story = {
 export const EmptyParticipants: Story = {
   args: {
     ...Default.args,
-    participants: [],
+    voteCount: 0,
+    availableParticipantNames: [],
+    unavailableParticipantNames: [],
   },
 };

--- a/src/domains/schedule/components/card-recommended/index.tsx
+++ b/src/domains/schedule/components/card-recommended/index.tsx
@@ -1,7 +1,5 @@
-import { format } from "date-fns";
-import { ko } from "date-fns/locale";
 import type { HTMLAttributes, MouseEvent } from "react";
-import { useId, useMemo, useState } from "react";
+import { useId, useState } from "react";
 import {
   AvailableIcon,
   ChevronDownIcon,
@@ -12,36 +10,34 @@ import { cn } from "@/shared/utils/cn";
 
 export interface CardRecommendedProps extends HTMLAttributes<HTMLDivElement> {
   index?: number;
-  date: { from: Date; to: Date };
-  participants: Participant[];
+  scheduleDate: string;
+  scheduleDayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  voteCount: number;
+  participantCount: number;
+  availableParticipantNames: string[];
+  unavailableParticipantNames: string[];
   expanded?: boolean;
   defaultExpanded?: boolean;
   onExpandedChange?: (expanded: boolean) => void;
 }
 
-interface Participant {
-  name: string;
-  isAvailable: boolean;
-}
-
-function processParticipants(participants: Participant[]) {
-  const available = participants.filter((p) => p.isAvailable);
-  const unavailable = participants.filter((p) => !p.isAvailable);
-
-  return {
-    availableCount: available.length,
-    availableNames: available.map((p) => p.name).join(", ") || "없음",
-    unavailableCount: unavailable.length,
-    unavailableNames: unavailable.map((p) => p.name).join(", ") || "없음",
-    participantCurrent: available.length,
-    participantTotal: participants.length,
-  };
+function formatDateLabel(scheduleDate: string, scheduleDayOfWeek: string) {
+  const [_, month, day] = scheduleDate.split("-");
+  return `${month}월 ${day}일 ${scheduleDayOfWeek}`;
 }
 
 export function CardRecommended({
   index = 1,
-  date,
-  participants,
+  scheduleDate,
+  scheduleDayOfWeek,
+  startTime,
+  endTime,
+  voteCount,
+  participantCount,
+  availableParticipantNames,
+  unavailableParticipantNames,
   className,
   expanded,
   defaultExpanded = false,
@@ -52,16 +48,12 @@ export function CardRecommended({
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
   const isExpanded = expanded ?? internalExpanded;
 
-  const dateLabel = format(date.from, "M월 d일 E요일", { locale: ko });
-  const timeLabel = `${format(date.from, "HH:mm")} ~ ${format(date.to, "HH:mm")}`;
-  const {
-    availableCount,
-    availableNames,
-    unavailableCount,
-    unavailableNames,
-    participantCurrent,
-    participantTotal,
-  } = useMemo(() => processParticipants(participants), [participants]);
+  const dateLabel = formatDateLabel(scheduleDate, scheduleDayOfWeek);
+  const timeLabel = `${startTime} ~ ${endTime}`;
+  const availableCount = availableParticipantNames.length;
+  const unavailableCount = unavailableParticipantNames.length;
+  const availableNames = availableParticipantNames.join(", ") || "없음";
+  const unavailableNames = unavailableParticipantNames.join(", ") || "없음";
 
   const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (event.defaultPrevented) {
@@ -97,8 +89,8 @@ export function CardRecommended({
           <p className="inline-flex items-center gap-0.5 text-b1">
             <MemberIcon className="size-5 shrink-0 text-primary-main" />
             <span className="text-b4">
-              <span className="text-primary-main">{participantCurrent}</span>
-              <span className="text-k-700">/{participantTotal}</span>
+              <span className="text-primary-main">{voteCount}</span>
+              <span className="text-k-700">/{participantCount}</span>
             </span>
           </p>
           <ChevronDownIcon

--- a/src/domains/schedule/components/schedule-main-hero/index.tsx
+++ b/src/domains/schedule/components/schedule-main-hero/index.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import GraphicPlaceholder from "@/assets/graphic/placeholder.svg?react";
+import { ScheduleEdit } from "@/domains/schedule/components/schedule-edit";
+import { useGetMeetingSchedules } from "@/domains/schedule/hooks/use-get-meeting-schedules";
+import { useGetMyParticipant } from "@/domains/schedule/hooks/use-get-my-participant";
+import { useListParticipants } from "@/domains/schedule/hooks/use-list-participants";
+
+export interface ScheduleMainHeroProps {
+  meetingId: string;
+  onEditSchedule: () => void;
+}
+
+export function ScheduleMainHero({
+  meetingId,
+  onEditSchedule,
+}: ScheduleMainHeroProps) {
+  const { data, isPending } = useGetMyParticipant({ meetingId });
+
+  if (isPending) {
+    return <ScheduleMainHeroSkeleton />;
+  }
+
+  if (data?.isHost) {
+    return (
+      <ScheduleMainHeroForHost
+        meetingId={meetingId}
+        onEditSchedule={onEditSchedule}
+      />
+    );
+  } else {
+    return <ScheduleMainHeroForParticipant meetingId={meetingId} />;
+  }
+}
+
+function ScheduleMainHeroSkeleton() {
+  return null;
+}
+
+function ScheduleMainHeroForHost({
+  meetingId,
+  onEditSchedule,
+}: {
+  meetingId: string;
+  onEditSchedule: () => void;
+}) {
+  const { data, isPending } = useGetMeetingSchedules({ meetingId });
+
+  if (!data || isPending) {
+    return <ScheduleMainHeroSkeleton />;
+  }
+
+  return (
+    <section className="w-full bg-k-50 px-5 pt-6 pb-4">
+      <div className="relative mb-5">
+        <h1 className="break-keep text-h1 text-k-900">
+          팀원에게 링크를
+          <br />
+          <span className="text-primary-main">공유</span>해보세요!
+        </h1>
+        <GraphicPlaceholder className="absolute right-0 -bottom-12 size-[118px] text-k-300" />
+      </div>
+      <ScheduleEdit
+        dates={data.dateOptions.map((date) => new Date(date))}
+        startTime={data.startTime}
+        endTime={data.endTime}
+        onEdit={onEditSchedule}
+        className="relative"
+      />
+    </section>
+  );
+}
+
+function ScheduleMainHeroForParticipant({ meetingId }: { meetingId: string }) {
+  const { data, isPending } = useListParticipants({ meetingId });
+
+  const hostName = useMemo(() => {
+    const host = data?.participants.find((participant) => participant.isHost);
+    return host?.name ?? "팀장";
+  }, [data?.participants]);
+
+  if (isPending) {
+    return <ScheduleMainHeroSkeleton />;
+  }
+
+  return (
+    <section className="relative w-full bg-k-50 px-5 pt-6 pb-5">
+      <h1 className="break-keep text-h1 text-k-900">
+        <span className="text-primary-main">{hostName}</span>님과 모임을
+        <br />
+        시작해보세요!
+      </h1>
+      <GraphicPlaceholder className="absolute right-0 -bottom-8 size-[118px] text-k-300" />
+    </section>
+  );
+}

--- a/src/domains/schedule/components/schedule-main-optimal-content/index.tsx
+++ b/src/domains/schedule/components/schedule-main-optimal-content/index.tsx
@@ -1,0 +1,160 @@
+import { type ReactNode, useMemo, useState } from "react";
+import { useParams } from "react-router";
+import GraphicPlaceholder from "@/assets/graphic/placeholder.svg?react";
+import { CardRecommended } from "@/domains/schedule/components/card-recommended";
+import { splitResults } from "@/domains/schedule/components/schedule-main-optimal-content/split-results";
+import { useGetMeetingScheduleVoteResults } from "@/domains/schedule/hooks/use-get-meeting-schedule-vote-results";
+import { useGetMeetingSchedules } from "@/domains/schedule/hooks/use-get-meeting-schedules";
+import { ButtonBottomWithIcon } from "@/shared/components/button-bottom-with-icon";
+import { ChevronDownIcon, ChevronUpIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+
+export function ScheduleMainOptimalContent() {
+  const { meetingId } = useParams() as { meetingId: string };
+  const { data, isPending } = useGetMeetingScheduleVoteResults({ meetingId });
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const results = data?.scheduleVoteResult ?? [];
+  const [visible, hidden] = useMemo(() => splitResults(results), [results]);
+
+  if (isPending) {
+    return (
+      <ScheduleMainOptimalPlaceholderContent
+        title="최적 일정을 불러오는 중이에요."
+        description="잠시만 기다려주세요."
+      />
+    );
+  }
+
+  if (data?.scheduleVoteResult.length === 0) {
+    return <ScheduleMainOptimalPlaceholder meetingId={meetingId} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="mb-2 text-b3 text-k-800">총 {results.length}개</div>
+      {visible.map((recommendation, index) => (
+        <CardRecommended
+          key={`${recommendation.scheduleDate}-${recommendation.startTime}-${recommendation.endTime}`}
+          index={index + 1}
+          scheduleDate={recommendation.scheduleDate}
+          scheduleDayOfWeek={recommendation.scheduleDayOfWeek}
+          startTime={recommendation.startTime}
+          endTime={recommendation.endTime}
+          voteCount={recommendation.voteCount}
+          participantCount={data?.participantCount ?? 0}
+          availableParticipantNames={recommendation.availableParticipantNames}
+          unavailableParticipantNames={
+            recommendation.unavailableParticipantNames
+          }
+        />
+      ))}
+
+      {hidden.length > 0 && (
+        <>
+          <div
+            className={cn(
+              "grid transition-[grid-template-rows,opacity] duration-200 ease-out",
+              isExpanded && "grid-rows-[1fr] opacity-100",
+              !isExpanded && "pointer-events-none grid-rows-[0fr] opacity-0",
+            )}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div className="mt-2 flex flex-col gap-2">
+                {hidden.map((recommendation, index) => (
+                  <CardRecommended
+                    key={`${recommendation.scheduleDate}-${recommendation.startTime}-${recommendation.endTime}`}
+                    index={visible.length + index + 1}
+                    scheduleDate={recommendation.scheduleDate}
+                    scheduleDayOfWeek={recommendation.scheduleDayOfWeek}
+                    startTime={recommendation.startTime}
+                    endTime={recommendation.endTime}
+                    voteCount={recommendation.voteCount}
+                    participantCount={data?.participantCount ?? 0}
+                    availableParticipantNames={
+                      recommendation.availableParticipantNames
+                    }
+                    unavailableParticipantNames={
+                      recommendation.unavailableParticipantNames
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <ButtonBottomWithIcon
+            className="mt-2"
+            icon={
+              isExpanded ? (
+                <ChevronUpIcon className="size-4 text-k-400" />
+              ) : (
+                <ChevronDownIcon className="size-4 text-k-400" />
+              )
+            }
+            aria-expanded={isExpanded}
+            onClick={() => setIsExpanded((prev) => !prev)}
+          >
+            {isExpanded ? "더보기 접기" : "최적일정 더보기"}
+          </ButtonBottomWithIcon>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ScheduleMainOptimalPlaceholder({ meetingId }: { meetingId: string }) {
+  const { data, isPending } = useGetMeetingSchedules({ meetingId });
+  const votedParticipantCount = data?.votedParticipantCount ?? 0;
+
+  if (isPending) {
+    return (
+      <ScheduleMainOptimalPlaceholderContent
+        title="최적 일정을 불러오는 중이에요."
+        description="잠시만 기다려주세요."
+      />
+    );
+  }
+
+  if (votedParticipantCount <= 1) {
+    return (
+      <ScheduleMainOptimalPlaceholderContent
+        title={
+          <>
+            아직 2명 이상의 일정이
+            <br />
+            등록되지 않았어요.
+          </>
+        }
+        description="링크를 공유하거나 일정을 등록해 보세요."
+      />
+    );
+  }
+
+  return (
+    <ScheduleMainOptimalPlaceholderContent
+      title="겹치는 시간대가 아직 없어요."
+      description="시간 범위를 넓히거나 일정을 다시 등록해 보세요."
+    />
+  );
+}
+
+function ScheduleMainOptimalPlaceholderContent({
+  title,
+  description,
+}: {
+  title: ReactNode;
+  description: ReactNode;
+}) {
+  return (
+    <div className="grid min-h-0 flex-1 place-items-center">
+      <div className="flex flex-col items-center text-center">
+        <GraphicPlaceholder className="size-[172px] text-k-300" />
+        <div className="mt-4 flex flex-col gap-3">
+          <p className="text-k-700 text-t1">{title}</p>
+          <p className="text-b4 text-k-500">{description}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/schedule/components/schedule-main-optimal-content/split-results.ts
+++ b/src/domains/schedule/components/schedule-main-optimal-content/split-results.ts
@@ -1,0 +1,14 @@
+import type { ScheduleVoteResult } from "@/domains/meeting/types/meeting-api-types";
+
+export const splitResults = (results: ScheduleVoteResult[]) => {
+  if (results.length <= 3) {
+    return [results, []];
+  }
+
+  const count = Math.min(results.length, 3);
+  const item = results[count - 1];
+  return [
+    results.filter((result) => result.voteCount >= item.voteCount),
+    results.filter((result) => result.voteCount < item.voteCount),
+  ];
+};

--- a/src/domains/schedule/components/schedule-main-vote-content/index.tsx
+++ b/src/domains/schedule/components/schedule-main-vote-content/index.tsx
@@ -1,0 +1,76 @@
+import { useParams } from "react-router";
+import { ScheduleMainVoteParticipants } from "@/domains/schedule/components/schedule-main-vote-participants";
+import { useGetMeetingScheduleVoteResults } from "@/domains/schedule/hooks/use-get-meeting-schedule-vote-results";
+import { useGetMeetingSchedules } from "@/domains/schedule/hooks/use-get-meeting-schedules";
+import { useGetMyParticipant } from "@/domains/schedule/hooks/use-get-my-participant";
+import { parseTime } from "@/domains/schedule/utils/parse";
+import { toScheduleOccupancy } from "@/domains/schedule/utils/timetable";
+import { Timetable } from "@/shared/components/timetable";
+
+export interface ScheduleMainVoteContentProps {
+  onParticipantEdit: () => void;
+}
+
+export function ScheduleMainVoteContent({
+  onParticipantEdit,
+}: ScheduleMainVoteContentProps) {
+  const { meetingId } = useParams() as { meetingId: string };
+
+  const schedulesQuery = useGetMeetingSchedules({ meetingId });
+  const voteResultsQuery = useGetMeetingScheduleVoteResults({ meetingId });
+  const myParticipantQuery = useGetMyParticipant({ meetingId });
+
+  if (
+    schedulesQuery.isPending ||
+    voteResultsQuery.isPending ||
+    !schedulesQuery.data ||
+    !voteResultsQuery.data
+  ) {
+    return (
+      <div className="py-10 text-center text-b4 text-k-500">
+        시간표를 불러오는 중이에요.
+      </div>
+    );
+  }
+
+  const myParticipantName = myParticipantQuery.data?.name;
+
+  return (
+    <>
+      <ScheduleMainVoteParticipants
+        meetingId={meetingId}
+        participantCount={schedulesQuery.data.participantCount}
+        votedParticipantCount={schedulesQuery.data.votedParticipantCount}
+        votedParticipantNames={schedulesQuery.data.participants
+          .filter((participant) => participant.scheduleVoteId)
+          .map((participant) => participant.name)}
+        onParticipantEdit={onParticipantEdit}
+      />
+      <Timetable
+        className="mt-3"
+        dates={schedulesQuery.data.dateOptions.map(
+          (dateOption) => new Date(dateOption),
+        )}
+        startTime={parseTime(schedulesQuery.data.startTime, 9)}
+        endTime={parseTime(schedulesQuery.data.endTime, 24)}
+        occupancy={toScheduleOccupancy(
+          voteResultsQuery.data.scheduleVoteResult,
+        )}
+        selected={
+          myParticipantName
+            ? voteResultsQuery.data.scheduleVoteResult
+                .filter((result) =>
+                  result.availableParticipantNames.includes(myParticipantName),
+                )
+                .map(
+                  (result) =>
+                    new Date(`${result.scheduleDate}T${result.startTime}`),
+                )
+            : []
+        }
+        disabled
+        stickyHeaderTop={48}
+      />
+    </>
+  );
+}

--- a/src/domains/schedule/components/schedule-main-vote-participants/index.tsx
+++ b/src/domains/schedule/components/schedule-main-vote-participants/index.tsx
@@ -1,0 +1,54 @@
+import { useGetMyParticipant } from "@/domains/schedule/hooks/use-get-my-participant";
+import { Chip } from "@/shared/components/chip";
+import { ChevronRightIcon, MemberIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+
+export function ScheduleMainVoteParticipants({
+  meetingId,
+  participantCount,
+  votedParticipantCount,
+  votedParticipantNames,
+  onParticipantEdit,
+}: {
+  meetingId: string;
+  participantCount: number;
+  votedParticipantCount: number;
+  votedParticipantNames: string[];
+  onParticipantEdit: () => void;
+}) {
+  const { data } = useGetMyParticipant({ meetingId });
+
+  const handleClickParticipantEdit = () => {
+    if (data?.isHost) {
+      onParticipantEdit();
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-3">
+      <button
+        type="button"
+        onClick={handleClickParticipantEdit}
+        className={cn(
+          "flex items-center py-1 text-k-800 text-t2",
+          data?.isHost && "cursor-pointer",
+        )}
+      >
+        <MemberIcon className="size-5" />
+        <span className="mr-0.5">참여자</span>
+        <span className="text-primary-main">{votedParticipantCount}</span>
+        <span className="mr-0.5">/{participantCount}</span>
+        {data?.isHost && <ChevronRightIcon className="size-4 text-k-400" />}
+      </button>
+      {votedParticipantNames.length > 0 && (
+        <div className="flex gap-1.5 overflow-x-auto">
+          {votedParticipantNames.map((name) => (
+            <Chip size="xl" key={name}>
+              {name}
+            </Chip>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/domains/schedule/hooks/use-get-meeting-schedule-vote-results.ts
+++ b/src/domains/schedule/hooks/use-get-meeting-schedule-vote-results.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMeetingScheduleVoteResults } from "@/domains/meeting/apis/meeting-api";
+
+export function getMeetingScheduleVoteResultsQueryKey({
+  meetingId,
+}: {
+  meetingId: string;
+}) {
+  return ["meeting", "schedule-vote-results", meetingId];
+}
+
+export function useGetMeetingScheduleVoteResults({
+  meetingId,
+}: {
+  meetingId: string;
+}) {
+  return useQuery({
+    queryFn: async () => {
+      const { data } = await getMeetingScheduleVoteResults({ meetingId });
+      return data.data;
+    },
+    queryKey: getMeetingScheduleVoteResultsQueryKey({ meetingId }),
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domains/schedule/hooks/use-get-meeting-schedules.ts
+++ b/src/domains/schedule/hooks/use-get-meeting-schedules.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMeetingSchedules } from "@/domains/meeting/apis/meeting-api";
+
+export function getMeetingSchedulesQueryKey({
+  meetingId,
+}: {
+  meetingId: string;
+}) {
+  return ["meeting", "schedules", meetingId];
+}
+
+export function useGetMeetingSchedules({ meetingId }: { meetingId: string }) {
+  return useQuery({
+    queryFn: async () => {
+      const { data } = await getMeetingSchedules({ meetingId });
+      return data.data;
+    },
+    queryKey: getMeetingSchedulesQueryKey({ meetingId }),
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domains/schedule/hooks/use-get-my-participant.ts
+++ b/src/domains/schedule/hooks/use-get-my-participant.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { getMyParticipant } from "@/domains/meeting/apis/participant-api";
+import { getGuestId } from "@/shared/utils/auth";
+
+export function getMyParticipantQueryKey({
+  localStorageKey,
+  meetingId,
+}: {
+  localStorageKey: string;
+  meetingId: string;
+}) {
+  return ["participant", "me", meetingId, localStorageKey];
+}
+
+export function useGetMyParticipant({ meetingId }: { meetingId: string }) {
+  const localStorageKey = getGuestId();
+
+  return useQuery({
+    queryFn: async () => {
+      try {
+        const { data } = await getMyParticipant({ localStorageKey, meetingId });
+        return data.data;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return null;
+        }
+
+        throw error;
+      }
+    },
+    queryKey: getMyParticipantQueryKey({ localStorageKey, meetingId }),
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domains/schedule/hooks/use-list-participants.ts
+++ b/src/domains/schedule/hooks/use-list-participants.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { listParticipants } from "@/domains/meeting/apis/participant-api";
+
+export function listParticipantsQueryKey({ meetingId }: { meetingId: string }) {
+  return ["participants", meetingId];
+}
+
+export function useListParticipants({ meetingId }: { meetingId: string }) {
+  return useQuery({
+    queryFn: async () => {
+      const { data } = await listParticipants({ meetingId });
+      return data.data;
+    },
+    queryKey: listParticipantsQueryKey({ meetingId }),
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domains/schedule/pages/meetings/[meeting-id]/schedule/index.tsx
+++ b/src/domains/schedule/pages/meetings/[meeting-id]/schedule/index.tsx
@@ -1,31 +1,45 @@
-import { Outlet, useNavigate } from "react-router";
-import { ButtonBottom } from "@/shared/components/button-bottom";
+import { useMemo } from "react";
+import { Outlet, useNavigate, useParams, useSearchParams } from "react-router";
+import { ScheduleMainView } from "@/domains/schedule/views/schedule-main-view";
 import { MobileLayout } from "@/shared/components/mobile-layout";
-import { PageHeader } from "@/shared/components/page-header";
 
 export function ScheduleMainPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { meetingId } = useParams() as { meetingId: string };
+
+  const tab = useMemo(
+    () => (searchParams.get("tab") === "optimal" ? "optimal" : "vote"),
+    [searchParams],
+  );
+
+  const handleAddVote = (scheduleVoteId?: number) => {
+    if (scheduleVoteId) {
+      navigate(`/meetings/${meetingId}/schedule/votes/${scheduleVoteId}`);
+      return;
+    }
+
+    navigate(`/meetings/${meetingId}/schedule/votes`);
+  };
+
+  const handleTabChange = (nextTab: "optimal" | "vote") => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set("tab", nextTab);
+    setSearchParams(nextSearchParams, { replace: true });
+  };
 
   return (
     <MobileLayout>
-      <section className="flex min-h-dvh flex-col px-5 pb-5">
-        <PageHeader title="일정 메인 화면" />
-
-        <div className="mt-4 flex flex-col gap-2">
-          <ButtonBottom onClick={() => navigate("edit/dates")} variant="white">
-            시간표 기간 편집
-          </ButtonBottom>
-          <ButtonBottom
-            onClick={() => navigate("edit/participants")}
-            variant="white"
-          >
-            모임 인원 수정
-          </ButtonBottom>
-          <ButtonBottom onClick={() => navigate("votes")} variant="white">
-            일정 추가하기
-          </ButtonBottom>
-        </div>
-      </section>
+      <ScheduleMainView
+        meetingId={meetingId}
+        tab={tab}
+        onAddVote={handleAddVote}
+        onEditSchedule={() => navigate("edit/dates")}
+        onParticipantEdit={() =>
+          navigate(`/meetings/${meetingId}/schedule/edit/participants`)
+        }
+        onTabChange={handleTabChange}
+      />
       <Outlet />
     </MobileLayout>
   );

--- a/src/domains/schedule/utils/parse.ts
+++ b/src/domains/schedule/utils/parse.ts
@@ -1,0 +1,13 @@
+export function parseTime(value: string, fallback: number) {
+  const [hourText, minuteText] = value.split(":");
+  const hour = Number(hourText);
+
+  if (!Number.isFinite(hour)) {
+    return fallback;
+  }
+
+  const minute = Number(minuteText ?? "0");
+  const total = hour + (Number.isFinite(minute) ? minute / 60 : 0);
+
+  return Math.min(24, Math.max(0, total));
+}

--- a/src/domains/schedule/utils/timetable.ts
+++ b/src/domains/schedule/utils/timetable.ts
@@ -1,0 +1,41 @@
+import type { ScheduleVoteResult } from "@/domains/meeting/types/meeting-api-types";
+
+export function parseScheduleSlotDate(dateText: string, timeText: string) {
+  const date = new Date(dateText);
+
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  const [hoursText, minutesText] = timeText.split(":");
+  const hours = Number(hoursText);
+  const minutes = Number(minutesText ?? "0");
+
+  if (Number.isFinite(hours) && Number.isFinite(minutes)) {
+    date.setHours(hours, minutes, 0, 0);
+  }
+
+  return date;
+}
+
+export function toScheduleOccupancy(results: ScheduleVoteResult[]) {
+  const occupancy: Record<string, number> = {};
+
+  for (const result of results) {
+    const from = parseScheduleSlotDate(result.scheduleDate, result.startTime);
+    const to = parseScheduleSlotDate(result.scheduleDate, result.endTime);
+
+    if (!from || !to) {
+      continue;
+    }
+
+    const current = new Date(from);
+    while (current < to) {
+      const key = current.getTime().toString();
+      occupancy[key] = Math.max(occupancy[key] ?? 0, result.voteCount);
+      current.setMinutes(current.getMinutes() + 30);
+    }
+  }
+
+  return occupancy;
+}

--- a/src/domains/schedule/views/schedule-main-view/index.tsx
+++ b/src/domains/schedule/views/schedule-main-view/index.tsx
@@ -1,0 +1,69 @@
+import type { HTMLAttributes } from "react";
+import { ScheduleMainHero } from "@/domains/schedule/components/schedule-main-hero";
+import { ScheduleMainOptimalContent } from "@/domains/schedule/components/schedule-main-optimal-content";
+import { ScheduleMainVoteContent } from "@/domains/schedule/components/schedule-main-vote-content";
+import { useGetMyParticipant } from "@/domains/schedule/hooks/use-get-my-participant";
+import { BottomActionBarWithButtonAndShare } from "@/shared/components/bottom-action-bar-with-button-and-share";
+import { FloatingScrollTop } from "@/shared/components/floating-scroll-top";
+import { Tab } from "@/shared/components/tab";
+import { cn } from "@/shared/utils/cn";
+
+export interface ScheduleMainViewProps extends HTMLAttributes<HTMLDivElement> {
+  meetingId: string;
+  tab: "optimal" | "vote";
+  onAddVote: (scheduleVoteId?: number) => void;
+  onEditSchedule: () => void;
+  onParticipantEdit: () => void;
+  onTabChange: (tab: "optimal" | "vote") => void;
+}
+
+export function ScheduleMainView({
+  className,
+  meetingId,
+  onAddVote,
+  onEditSchedule,
+  onParticipantEdit,
+  onTabChange,
+  tab,
+  ...props
+}: ScheduleMainViewProps) {
+  const { data } = useGetMyParticipant({ meetingId });
+
+  return (
+    <div
+      className={cn("relative flex min-h-dvh flex-col bg-k-5", className)}
+      {...props}
+    >
+      <ScheduleMainHero meetingId={meetingId} onEditSchedule={onEditSchedule} />
+
+      <section className="sticky top-0 z-30 shrink-0 bg-k-5">
+        <Tab
+          tabs={[
+            { id: "vote", label: "시간표" },
+            { id: "optimal", label: "최적일정" },
+          ]}
+          activeTabId={tab}
+          onTabChange={(id) =>
+            onTabChange(id === "optimal" ? "optimal" : "vote")
+          }
+        />
+      </section>
+
+      <section className="flex min-h-0 flex-1 flex-col px-5 py-3 pb-[106px]">
+        {tab === "vote" && (
+          <ScheduleMainVoteContent onParticipantEdit={onParticipantEdit} />
+        )}
+        {tab === "optimal" && <ScheduleMainOptimalContent />}
+      </section>
+
+      <FloatingScrollTop top={4} className="bottom-[92px]" />
+
+      <BottomActionBarWithButtonAndShare
+        onClick={() => onAddVote(data?.scheduleVoteId)}
+        onShare={() => console.log("TODO: share")}
+      >
+        일정 추가하기
+      </BottomActionBarWithButtonAndShare>
+    </div>
+  );
+}

--- a/src/shared/components/bottom-action-bar-with-button-and-share/index.tsx
+++ b/src/shared/components/bottom-action-bar-with-button-and-share/index.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import {
+  BottomActionBar,
+  type BottomActionBarTone,
+} from "@/shared/components/bottom-action-bar";
+import { ButtonBottom } from "@/shared/components/button-bottom";
+import { IconButton } from "@/shared/components/icon-button";
+import { ShareIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+
+export interface BottomActionBarWithButtonAndShareProps {
+  tone?: BottomActionBarTone;
+  onClick: () => void;
+  onShare: () => void;
+  disabled?: boolean;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function BottomActionBarWithButtonAndShare({
+  tone,
+  onClick,
+  onShare,
+  children,
+  className,
+}: BottomActionBarWithButtonAndShareProps) {
+  return (
+    <BottomActionBar
+      tone={tone}
+      className={cn("flex items-center gap-2", className)}
+    >
+      <ShareIconButton onClick={onShare} />
+      <ButtonBottom onClick={onClick} className="w-full flex-1" variant="black">
+        {children}
+      </ButtonBottom>
+    </BottomActionBar>
+  );
+}
+
+const ShareIconButton = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <IconButton
+      icon={ShareIcon}
+      size="2xl"
+      background="square"
+      backgroundSize="lg"
+      iconSize="xl"
+      variant="dark"
+      onClick={onClick}
+    />
+  );
+};

--- a/src/shared/components/bottom-action-bar/index.tsx
+++ b/src/shared/components/bottom-action-bar/index.tsx
@@ -1,0 +1,32 @@
+import type { HTMLAttributes } from "react";
+import { useScrolled } from "@/shared/hooks/use-scrolled";
+import { cn } from "@/shared/utils/cn";
+
+export type BottomActionBarTone = "solid" | "scroll-solid";
+
+export interface BottomActionBarProps extends HTMLAttributes<HTMLDivElement> {
+  tone?: BottomActionBarTone;
+}
+
+export function BottomActionBar({
+  tone = "solid",
+  className,
+  ...props
+}: BottomActionBarProps) {
+  const { scrolled } = useScrolled({
+    top: tone === "scroll-solid" ? 1 : 0,
+  });
+
+  return (
+    <div
+      className={cn(
+        "fixed right-0 bottom-0 left-0 z-30 mx-auto w-full max-w-[375px] px-5 pt-3 pb-3 transition-colors",
+        tone === "solid" || scrolled
+          ? "border-k-50 border-t bg-k-5"
+          : "bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/shared/components/timetable/index.stories.tsx
+++ b/src/shared/components/timetable/index.stories.tsx
@@ -99,3 +99,45 @@ export const Weekly: Story = {
     occupancy: mockOccupancy,
   },
 };
+
+/** 4. 30분 단위 시작/종료 (21:30 ~ 23:00) */
+export const HalfHourBoundary: Story = {
+  name: "30분 단위 (21:30~23:00)",
+  render: (args) => {
+    const [selected, setSelected] = useState<Date[]>([]);
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="font-medium text-k-500 text-sm">
+          21:30 시작 · 선택된 슬롯: {selected.length}개
+        </p>
+        <Timetable {...args} selected={selected} onSelect={setSelected} />
+      </div>
+    );
+  },
+  args: {
+    startTime: 21.5,
+    endTime: 23,
+    dates: getDates(5),
+  },
+};
+
+/** 5. 30분 단위 시작 + 30분 단위 종료 (9:30 ~ 18:30) */
+export const HalfHourBoth: Story = {
+  name: "30분 단위 양쪽 (9:30~18:30)",
+  render: (args) => {
+    const [selected, setSelected] = useState<Date[]>([]);
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="font-medium text-k-500 text-sm">
+          9:30 ~ 18:30 · 선택된 슬롯: {selected.length}개
+        </p>
+        <Timetable {...args} selected={selected} onSelect={setSelected} />
+      </div>
+    );
+  },
+  args: {
+    startTime: 9.5,
+    endTime: 18.5,
+    dates: getDates(4),
+  },
+};

--- a/src/shared/components/timetable/index.tsx
+++ b/src/shared/components/timetable/index.tsx
@@ -49,7 +49,7 @@ export function Timetable({
   occupancy = {},
   stickyHeaderTop = 0,
 }: TimetableProps) {
-  const totalSlots = (endTime - startTime) * 2;
+  const totalSlots = Math.round((endTime - startTime) * 2);
 
   const {
     selectedSlots,
@@ -260,9 +260,11 @@ export function Timetable({
           style={{ gridTemplateColumns: bodyGridTemplateColumns }}
         >
           {Array.from({ length: totalSlots }).map((_, slotIdx) => {
-            const isHourStart = slotIdx % 2 === 0;
-            const currentHour = startTime + Math.floor(slotIdx / 2);
-            const currentMinutes = slotIdx % 2 !== 0 ? 30 : 0;
+            const startMinutes = startTime * 60;
+            const slotMinutes = startMinutes + slotIdx * 30;
+            const currentHour = Math.floor(slotMinutes / 60);
+            const currentMinutes = slotMinutes % 60;
+            const isHourStart = currentMinutes === 0;
             const isFirstSlot = slotIdx === 0;
             const isLastSlot = slotIdx === totalSlots - 1;
 
@@ -280,7 +282,7 @@ export function Timetable({
                     </span>
                   )}
 
-                  {isLastSlot && (
+                  {isLastSlot && endTime % 1 === 0 && (
                     <span className="absolute bottom-0 left-0 z-20 w-full bg-k-5 text-b3 text-k-500">
                       {String(endTime)}
                     </span>

--- a/src/shared/components/timetable/use-timetable-drag-selection.ts
+++ b/src/shared/components/timetable/use-timetable-drag-selection.ts
@@ -61,8 +61,10 @@ export function useTimetableDragSelection({
   const getSlotDate = useCallback(
     (dateIdx: number, slotIdx: number) => {
       const baseDate = dates[dateIdx];
-      const hour = startTime + Math.floor(slotIdx / 2);
-      const minutes = slotIdx % 2 !== 0 ? 30 : 0;
+      const startMinutes = startTime * 60;
+      const slotMinutes = startMinutes + slotIdx * 30;
+      const hour = Math.floor(slotMinutes / 60);
+      const minutes = slotMinutes % 60;
 
       const slotDate = new Date(baseDate);
       slotDate.setHours(hour, minutes, 0, 0);


### PR DESCRIPTION
## Summary

- 일정 메인 화면을 구현했습니다.

## References

- closes #42

## Stacks

<!-- ejoffe/spr start -->
**Stack**:
- #101
- #90
- #89 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timetable voting view and participant vote UI
  * Vote-results list with collapsible "optimal" section and placeholders
  * Distinct host vs participant hero layouts
  * Bottom action bar with share and primary action; participant list display and edit affordance

* **Refactor**
  * Card props converted to explicit schedule fields (date, times, counts, name arrays)
  * Timetable slot/time calculations adjusted for accurate half-hour boundaries and slot rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->