### PR TITLE
fix: 서비스 지역 밖 출발지(독도 등) 등록 차단 및 중간지점 에러 대응

### DIFF
--- a/src/domains/location/components/card-location-member/index.tsx
+++ b/src/domains/location/components/card-location-member/index.tsx
@@ -9,12 +9,14 @@ export interface CardLocationMemberProps
   name: string;
   address: string;
   durationMinutes: number;
+  unreachable?: boolean;
 }
 
 export function CardLocationMember({
   name,
   address,
   durationMinutes,
+  unreachable = false,
   className,
   ...props
 }: CardLocationMemberProps) {
@@ -37,8 +39,10 @@ export function CardLocationMember({
         </span> */}
       </div>
       <div className="flex shrink-0 items-center gap-1">
-        <span className="text-k-900 text-t2">
-          {formatDuration(durationMinutes)}
+        <span
+          className={unreachable ? "text-b4 text-k-400" : "text-k-900 text-t2"}
+        >
+          {unreachable ? "경로 없음" : formatDuration(durationMinutes)}
         </span>
         <ChevronRightIcon className="size-6 shrink-0 text-k-400" />
       </div>

--- a/src/domains/location/hooks/use-create-departure-form.ts
+++ b/src/domains/location/hooks/use-create-departure-form.ts
@@ -7,23 +7,50 @@ import { useCreateDeparture } from "@/domains/location/hooks/use-create-departur
 import { getDeparturesQueryKey } from "@/domains/location/hooks/use-get-departures";
 import { getMidpointRecommendationsQueryKey } from "@/domains/location/hooks/use-get-midpoint-recommendations";
 import type { CreateLocationVoteRequest } from "@/domains/location/types/location-api-types";
+import {
+  isOutOfServiceAreaError,
+  isWithinServiceArea,
+  OUT_OF_SERVICE_AREA_MESSAGE,
+} from "@/domains/location/utils/service-area";
 import { toast } from "@/shared/components/toast";
 import { getGuestId } from "@/shared/utils/auth";
 
 export const NAME_MAX_LENGTH = 4;
 
-export const createDepartureFormSchema = z.object({
-  meetingId: z.string(),
-  participantName: z
-    .string()
-    .trim()
-    .max(NAME_MAX_LENGTH, `최대 ${NAME_MAX_LENGTH}자까지 적을 수 있어요`)
-    .optional(),
-  participantId: z.string().optional(),
-  departureLocation: z.string().min(1, "출발지를 선택해주세요"),
-  departureLat: z.string().min(1),
-  departureLng: z.string().min(1),
-});
+export function refineServiceArea(
+  values: { departureLat: string; departureLng: string },
+  ctx: z.RefinementCtx,
+) {
+  if (!values.departureLat || !values.departureLng) return;
+
+  if (
+    !isWithinServiceArea(
+      Number(values.departureLat),
+      Number(values.departureLng),
+    )
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["departureLocation"],
+      message: OUT_OF_SERVICE_AREA_MESSAGE,
+    });
+  }
+}
+
+export const createDepartureFormSchema = z
+  .object({
+    meetingId: z.string(),
+    participantName: z
+      .string()
+      .trim()
+      .max(NAME_MAX_LENGTH, `최대 ${NAME_MAX_LENGTH}자까지 적을 수 있어요`)
+      .optional(),
+    participantId: z.string().optional(),
+    departureLocation: z.string().min(1, "출발지를 선택해주세요"),
+    departureLat: z.string().min(1),
+    departureLng: z.string().min(1),
+  })
+  .superRefine(refineServiceArea);
 
 export type CreateDepartureFormValues = z.infer<
   typeof createDepartureFormSchema
@@ -84,6 +111,10 @@ export function useCreateDepartureForm(
       navigate(`/meetings/${meetingId}/location/votes`);
     } catch (error) {
       console.error("출발지 추가 실패:", error);
+      if (isOutOfServiceAreaError(error)) {
+        toast.error(OUT_OF_SERVICE_AREA_MESSAGE);
+        return;
+      }
       toast.error("출발지 추가에 실패했어요. 잠시 후 다시 시도해주세요.");
     }
   });
@@ -99,6 +130,10 @@ export function useCreateDepartureForm(
       !!watch("departureLng") &&
       watch("departureLat") !== "undefined" &&
       watch("departureLng") !== "undefined" &&
+      isWithinServiceArea(
+        Number(watch("departureLat")),
+        Number(watch("departureLng")),
+      ) &&
       (!!watch("participantName")?.trim() || !!watch("participantId")),
     isSubmitPending: createDepartureMutation.isPending,
     maxNameLength: NAME_MAX_LENGTH,

--- a/src/domains/location/hooks/use-get-midpoint-recommendations.ts
+++ b/src/domains/location/hooks/use-get-midpoint-recommendations.ts
@@ -17,6 +17,17 @@ interface MidpointInsufficientDepartureData {
   totalCount?: number;
 }
 
+export interface MidpointQueryData
+  extends Omit<
+    MidpointRecommendationResponse,
+    "registeredCount" | "totalCount"
+  > {
+  /** 무게중심 반경 내 지하철역이 없어 추천 불가 (E417) */
+  noNearbyStations?: boolean;
+  registeredCount?: number;
+  totalCount?: number;
+}
+
 function normalizeMidpointResponse(
   response: MidpointRecommendationResponse,
 ): MidpointRecommendationResponse {
@@ -46,7 +57,7 @@ export function useGetMidpointRecommendations({
   departureTime,
 }: GetMidpointRecommendationsParams) {
   return useQuery({
-    queryFn: async () => {
+    queryFn: async (): Promise<MidpointQueryData> => {
       try {
         const { data } = await getMidpointRecommendations({
           meetingId,
@@ -55,6 +66,19 @@ export function useGetMidpointRecommendations({
 
         return normalizeMidpointResponse(data.data);
       } catch (error) {
+        // E417: 출발지들의 무게중심 반경 내 지하철역이 없음 (서로 너무 멀리 떨어진 경우)
+        if (
+          axios.isAxiosError<ApiResponse<unknown>>(error) &&
+          error.response?.data?.code === "E417"
+        ) {
+          return {
+            centerPoint: DEFAULT_CENTER,
+            departureTime,
+            recommendations: [],
+            noNearbyStations: true,
+          };
+        }
+
         if (
           axios.isAxiosError<ApiResponse<MidpointInsufficientDepartureData>>(
             error,

--- a/src/domains/location/hooks/use-get-personal-route.ts
+++ b/src/domains/location/hooks/use-get-personal-route.ts
@@ -51,6 +51,11 @@ export function useGetPersonalRoute(params: GetPersonalRouteParams) {
           return null;
         }
 
+        // E428: 출발지에서 해당 역까지 이동 경로 없음 (독도 등 도달 불가 출발지)
+        if (axios.isAxiosError(error) && apiError?.code === "E428") {
+          return null;
+        }
+
         throw error;
       }
     },

--- a/src/domains/location/hooks/use-update-departure-form.ts
+++ b/src/domains/location/hooks/use-update-departure-form.ts
@@ -3,23 +3,33 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import { z } from "zod";
-import { NAME_MAX_LENGTH } from "@/domains/location/hooks/use-create-departure-form";
+import {
+  NAME_MAX_LENGTH,
+  refineServiceArea,
+} from "@/domains/location/hooks/use-create-departure-form";
 import { getDeparturesQueryKey } from "@/domains/location/hooks/use-get-departures";
 import { getMidpointRecommendationsQueryKey } from "@/domains/location/hooks/use-get-midpoint-recommendations";
 import { useUpdateDeparture } from "@/domains/location/hooks/use-update-departure";
 import type { UpdateLocationVoteRequest } from "@/domains/location/types/location-api-types";
+import {
+  isOutOfServiceAreaError,
+  isWithinServiceArea,
+  OUT_OF_SERVICE_AREA_MESSAGE,
+} from "@/domains/location/utils/service-area";
 import { toast } from "@/shared/components/toast";
 
-export const updateDepartureFormSchema = z.object({
-  participantName: z
-    .string()
-    .trim()
-    .min(1, "이름을 입력해주세요")
-    .max(NAME_MAX_LENGTH, `최대 ${NAME_MAX_LENGTH}자까지 적을 수 있어요`),
-  departureLocation: z.string().min(1, "출발지를 선택해주세요"),
-  departureLat: z.string().min(1),
-  departureLng: z.string().min(1),
-});
+export const updateDepartureFormSchema = z
+  .object({
+    participantName: z
+      .string()
+      .trim()
+      .min(1, "이름을 입력해주세요")
+      .max(NAME_MAX_LENGTH, `최대 ${NAME_MAX_LENGTH}자까지 적을 수 있어요`),
+    departureLocation: z.string().min(1, "출발지를 선택해주세요"),
+    departureLat: z.string().min(1),
+    departureLng: z.string().min(1),
+  })
+  .superRefine(refineServiceArea);
 
 export type UpdateDepartureFormValues = z.infer<
   typeof updateDepartureFormSchema
@@ -85,6 +95,10 @@ export function useUpdateDepartureForm({
       navigate(`/meetings/${meetingId}/location/votes`);
     } catch (error) {
       console.error("출발지 수정 실패:", error);
+      if (isOutOfServiceAreaError(error)) {
+        toast.error(OUT_OF_SERVICE_AREA_MESSAGE);
+        return;
+      }
       toast.error("출발지 수정에 실패했어요. 잠시 후 다시 시도해주세요.");
     }
   });
@@ -100,7 +114,11 @@ export function useUpdateDepartureForm({
       !!watch("departureLat") &&
       !!watch("departureLng") &&
       watch("departureLat") !== "undefined" &&
-      watch("departureLng") !== "undefined",
+      watch("departureLng") !== "undefined" &&
+      isWithinServiceArea(
+        Number(watch("departureLat")),
+        Number(watch("departureLng")),
+      ),
     isSubmitPending: updateDepartureMutation.isPending,
     maxNameLength: NAME_MAX_LENGTH,
     onSubmit,

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -281,6 +281,7 @@ export function LocationMainPage() {
                     name={locationVote.participantName}
                     address={route.departureAddress}
                     durationMinutes={route.transitDuration}
+                    unreachable={route.transitReachable === false}
                     onClick={() =>
                       navigate(
                         `/meetings/${meetingId}/location/stations/${selectedStation.stationId}/participants/${route.participantId}?${LOCATION_QUERY_PARAMS.routeTab}=${ROUTE_TAB_VALUES.transit}`,
@@ -290,6 +291,14 @@ export function LocationMainPage() {
                 );
               })}
             </div>
+          </div>
+        ) : midpoint?.noNearbyStations ? (
+          <div className="flex min-h-full flex-col px-5 pb-[106px]">
+            <PlaceholderContent
+              graphic={<PlaceholderGraphic className="h-[90px] w-[104px]" />}
+              title="중간지점을 찾지 못했어요"
+              description="출발지들이 서로 너무 멀리 떨어져 있어요. 출발지를 다시 확인해주세요"
+            />
           </div>
         ) : (
           <div className="flex min-h-full flex-col px-5 pb-[106px]">

--- a/src/domains/location/pages/meetings/[meeting-id]/location/votes/new/search/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/votes/new/search/index.tsx
@@ -5,11 +5,16 @@ import { ButtonSubStroke } from "@/domains/location/components/button-sub-stroke
 import { ItemSearchResult } from "@/domains/location/components/item-search-result";
 import { useCurrentLocation } from "@/domains/location/hooks/use-current-location";
 import { usePlaceSearch } from "@/domains/location/hooks/use-place-search";
+import {
+  isWithinServiceArea,
+  OUT_OF_SERVICE_AREA_MESSAGE,
+} from "@/domains/location/utils/service-area";
 import { SearchIcon, TargetIcon } from "@/shared/components/icons";
 import { MobileLayout } from "@/shared/components/mobile-layout";
 import { PageHeader } from "@/shared/components/page-header";
 import { PlaceholderContent } from "@/shared/components/placeholder-content";
 import { TextField } from "@/shared/components/text-field";
+import { toast } from "@/shared/components/toast";
 
 interface VoteSearchLocationState {
   address?: string;
@@ -56,6 +61,11 @@ export function DepartureNewSearchPage() {
   useEffect(() => {
     if (!currentAddress) return;
 
+    if (currentCoords && !isWithinServiceArea(...currentCoords)) {
+      toast.error(OUT_OF_SERVICE_AREA_MESSAGE);
+      return;
+    }
+
     navigate("..", {
       state: {
         ...location.state,
@@ -101,15 +111,21 @@ export function DepartureNewSearchPage() {
                 text={item.title}
                 description={item.roadAddress || item.address}
                 highlight={keyword}
-                onClick={() =>
+                onClick={() => {
+                  const lat = Number(item.y);
+                  const lng = Number(item.x);
+                  if (!isWithinServiceArea(lat, lng)) {
+                    toast.error(OUT_OF_SERVICE_AREA_MESSAGE);
+                    return;
+                  }
                   navigate("..", {
                     state: {
                       ...location.state,
                       address: item.roadAddress || item.address,
-                      coords: [Number(item.y), Number(item.x)],
+                      coords: [lat, lng],
                     },
-                  })
-                }
+                  });
+                }}
               />
             ))}
 

--- a/src/domains/location/types/location-api-types.ts
+++ b/src/domains/location/types/location-api-types.ts
@@ -34,9 +34,13 @@ export interface RouteDto {
   departureName: string;
   drivingDistance: number;
   drivingDuration: number;
+  /** false면 drivingDuration은 999 고정값 */
+  drivingReachable?: boolean;
   participantId: number;
   transitDistance: number;
   transitDuration: number;
+  /** false면 transitDuration은 999 고정값 */
+  transitReachable?: boolean;
 }
 
 export interface StationRecommendationDto {

--- a/src/domains/location/utils/service-area.test.ts
+++ b/src/domains/location/utils/service-area.test.ts
@@ -1,0 +1,58 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import { describe, expect, it } from "vitest";
+import {
+  isOutOfServiceAreaError,
+  isWithinServiceArea,
+} from "@/domains/location/utils/service-area";
+
+function createAxiosError(code: string) {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError("Request failed", "ERR_BAD_REQUEST", config, null, {
+    config,
+    data: { code },
+    headers: {},
+    status: 400,
+    statusText: "Bad Request",
+  });
+}
+
+describe("isWithinServiceArea", () => {
+  it("수도권 좌표(서울시청)는 서비스 지역이다", () => {
+    expect(isWithinServiceArea(37.5665, 126.978)).toBe(true);
+  });
+
+  it("수도권 전철망 경계 좌표(신창역, 춘천역)는 서비스 지역이다", () => {
+    expect(isWithinServiceArea(36.7695, 127.1046)).toBe(true);
+    expect(isWithinServiceArea(37.8853, 127.7173)).toBe(true);
+  });
+
+  it("독도는 서비스 지역이 아니다", () => {
+    expect(isWithinServiceArea(37.2426, 131.8597)).toBe(false);
+  });
+
+  it("제주는 서비스 지역이 아니다", () => {
+    expect(isWithinServiceArea(33.4996, 126.5312)).toBe(false);
+  });
+
+  it("부산은 서비스 지역이 아니다", () => {
+    expect(isWithinServiceArea(35.1796, 129.0756)).toBe(false);
+  });
+
+  it("숫자가 아닌 값(NaN)은 서비스 지역이 아니다", () => {
+    expect(isWithinServiceArea(Number.NaN, 126.978)).toBe(false);
+  });
+});
+
+describe("isOutOfServiceAreaError", () => {
+  it("E427 응답이면 true를 반환한다", () => {
+    expect(isOutOfServiceAreaError(createAxiosError("E427"))).toBe(true);
+  });
+
+  it("다른 에러 코드면 false를 반환한다", () => {
+    expect(isOutOfServiceAreaError(createAxiosError("E500"))).toBe(false);
+  });
+
+  it("Axios 에러가 아니면 false를 반환한다", () => {
+    expect(isOutOfServiceAreaError(new Error("boom"))).toBe(false);
+  });
+});

--- a/src/domains/location/utils/service-area.ts
+++ b/src/domains/location/utils/service-area.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+
+// 백엔드 LocationVoteServiceImpl의 서비스 지역 bounding box와 동일한 값 (E427 검증 기준)
+const SERVICE_AREA = {
+  minLat: 36.5,
+  maxLat: 38.2,
+  minLng: 126.2,
+  maxLng: 128.0,
+};
+
+export const OUT_OF_SERVICE_AREA_MESSAGE =
+  "아직 수도권에서만 이용할 수 있어요. 수도권 내 출발지를 선택해주세요";
+
+export const OUT_OF_SERVICE_AREA_ERROR_CODE = "E427";
+
+export function isWithinServiceArea(latitude: number, longitude: number) {
+  return (
+    latitude >= SERVICE_AREA.minLat &&
+    latitude <= SERVICE_AREA.maxLat &&
+    longitude >= SERVICE_AREA.minLng &&
+    longitude <= SERVICE_AREA.maxLng
+  );
+}
+
+export function isOutOfServiceAreaError(error: unknown) {
+  return (
+    axios.isAxiosError<{ code?: string }>(error) &&
+    error.response?.data?.code === OUT_OF_SERVICE_AREA_ERROR_CODE
+  );
+}


### PR DESCRIPTION
## Summary

- 출발지를 독도 등 서비스 지역(수도권) 밖으로 등록하면 중간지점 화면에서 서버 에러가 나는 문제 대응 (closes #124)
- `service-area.ts` 유틸 신설 — 백엔드 E427 검증과 동일한 수도권 bounding box + 유닛 테스트 9개
- 장소 검색/현위치 선택 시 지역 밖 좌표 차단 + "아직 수도권에서만 이용할 수 있어요" 토스트
- 출발지 등록·수정 폼: zod superRefine 2차 검증, `canSubmit` 차단, 서버 E427 응답 시 전용 토스트
- 중간지점 조회 E417(반경 내 역 없음) 처리 → 에러 대신 "중간지점을 찾지 못했어요" 안내 화면
- 도달 불가 참가자는 999분 대신 "경로 없음" 표시 (`transitReachable` 연동)
- 개인별 경로 E428(경로 없음)은 기존 "루트 정보를 찾을 수 없어요" fallback으로 연결

## Screenshots

| as-is | to-be |
| - | - |
| 독도 출발지 등록 가능 → 중간지점 진입 시 서버 에러 | 검색 단계에서 차단 토스트, 기존 데이터는 안내 화면/경로 없음 표시 |

## References
- 백엔드 PR: dnd-side-project/dnd-14th-8-backend fix/#139-out-of-service-area (E427/E428/E429 응답과 연동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-area validation for departure locations and map search results.
  * Added clear guidance when selected locations are outside the available service area.
  * Added messaging for unavailable routes and areas with no nearby stations.
  * Improved display of members whose transit route is unreachable.

* **Bug Fixes**
  * Personal route and midpoint searches now handle unavailable-route responses gracefully.
  * Departure forms prevent submission when locations are outside the supported area.

* **Tests**
  * Added coverage for service-area boundaries and related error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->