### PR TITLE
fix: 중간지점 화면 뒤로가기 히스토리 개선

### DIFF
--- a/src/domains/location/pages/meetings/[meeting-id]/location/nearby/[coords]/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/nearby/[coords]/index.tsx
@@ -161,6 +161,7 @@ export function NearbySearchPage() {
 
           navigate(
             `/meetings/${meetingId}/location/nearby/${stationCoordsPath}?${next.toString()}`,
+            { replace: true },
           );
         }}
       />
@@ -189,7 +190,7 @@ export function NearbySearchPage() {
           latitude={place.latitude}
           longitude={place.longitude}
           onClick={() =>
-            window.location.assign(
+            navigate(
               `/meetings/${meetingId}/location/nearby/${normalizedCoords}/places/${place.id}?${searchParams.toString()}`,
             )
           }
@@ -220,7 +221,7 @@ export function NearbySearchPage() {
                     LOCATION_QUERY_PARAMS.nearbyCategory,
                     categoryPlaces.category,
                   );
-                  setSearchParams(next);
+                  setSearchParams(next, { replace: true });
                 }}
               >
                 {categoryPlaces.category}
@@ -237,7 +238,7 @@ export function NearbySearchPage() {
                 isOpen={place.isOpen}
                 businessStatusMessage={place.businessStatusMessage}
                 onClick={() =>
-                  window.location.assign(
+                  navigate(
                     `/meetings/${meetingId}/location/nearby/${normalizedCoords}/places/${place.id}?${searchParams.toString()}`,
                   )
                 }

--- a/src/domains/location/pages/meetings/[meeting-id]/location/nearby/[coords]/places/[place-id]/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/nearby/[coords]/places/[place-id]/index.tsx
@@ -135,6 +135,7 @@ export function PlaceDetailPage() {
 
           navigate(
             `/meetings/${meetingId}/location/nearby/${stationCoordsPath}?${next.toString()}`,
+            { replace: true },
           );
         }}
       />
@@ -207,6 +208,7 @@ export function PlaceDetailPage() {
                 onClick={() =>
                   navigate(
                     `/meetings/${meetingId}/location/nearby/${coordsPath}?${searchParams.toString()}`,
+                    { replace: true },
                   )
                 }
               >

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/[station-id]/participants/[participant-id]/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/[station-id]/participants/[participant-id]/index.tsx
@@ -132,6 +132,7 @@ export function RouteDetailPage() {
         onStationClick={(station) => {
           navigate(
             `/meetings/${meetingId}/location/stations/${station.stationId}/participants/${participantId}?${LOCATION_QUERY_PARAMS.routeTab}=${activeTab}`,
+            { replace: true },
           );
         }}
       />
@@ -188,6 +189,7 @@ export function RouteDetailPage() {
                   onClick={() =>
                     navigate(
                       `/meetings/${meetingId}/location/stations/${station.stationId}/participants/${participantId}?${LOCATION_QUERY_PARAMS.routeTab}=${activeTab}`,
+                      { replace: true },
                     )
                   }
                 >
@@ -213,7 +215,7 @@ export function RouteDetailPage() {
                     ? ROUTE_TAB_VALUES.driving
                     : ROUTE_TAB_VALUES.transit,
                 );
-                setSearchParams(next);
+                setSearchParams(next, { replace: true });
               }}
             />
 
@@ -259,6 +261,7 @@ export function RouteDetailPage() {
               onClick={() =>
                 navigate(
                   `/meetings/${meetingId}/location/stations?${LOCATION_QUERY_PARAMS.stationId}=${personalRoute.station.stationId}`,
+                  { replace: true },
                 )
               }
             >
@@ -275,6 +278,7 @@ export function RouteDetailPage() {
               onClick={() =>
                 navigate(
                   `/meetings/${meetingId}/location/stations?${LOCATION_QUERY_PARAMS.stationId}=${stationId}`,
+                  { replace: true },
                 )
               }
             >

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -147,7 +147,7 @@ export function LocationMainPage() {
   const handleStationClick = (stationId: number) => {
     const next = new URLSearchParams(searchParams);
     next.set(LOCATION_QUERY_PARAMS.stationId, String(stationId));
-    setSearchParams(next);
+    setSearchParams(next, { replace: true });
   };
 
   const handleMoveNearby = () => {
@@ -158,7 +158,7 @@ export function LocationMainPage() {
       longitude: selectedStation.longitude,
     });
 
-    window.location.assign(
+    navigate(
       `/meetings/${meetingId}/location/nearby/${coordsPath}?${LOCATION_QUERY_PARAMS.stationId}=${selectedStation.stationId}`,
     );
   };


### PR DESCRIPTION
Closes #125

## 변경 내용

중간지점 관련 4개 화면에서 히스토리 처리 원칙을 통일했습니다: **화면 전환은 push, 같은 화면 내 상태 변경(역 선택·카테고리·탭)은 replace, 복귀 버튼도 replace**. 이제 뒤로가기가 클릭 이력이 아니라 화면 단위로 동작합니다.

- **결과 화면** (`stations/index.tsx`): 역 칩/마커 선택 replace화, "주변 둘러보기" 진입의 `window.location.assign` 전체 리로드 → `navigate()` SPA 전환
- **주변 둘러보기** (`nearby/[coords]/index.tsx`): 역 배지·카테고리 칩 replace화, 장소 상세 진입 2곳 전체 리로드 제거
- **루트 상세** (`.../participants/[participant-id]/index.tsx`): 대중교통↔자동차 탭·역 변경 replace화, "지도에서 보기"/"추천역 목록으로 돌아가기" replace화
- **장소 상세** (`.../places/[place-id]/index.tsx`): 역 배지·"주변 장소 목록으로" replace화

## 검증

- `pnpm check` / `pnpm build` / `pnpm vitest run` (40 files, 107 tests) 전부 통과
- 태스크별 코드 리뷰 4회 + 전체 브랜치 최종 리뷰 완료
- [ ] 수동 브라우저 검증 (아래 시나리오)

### 수동 검증 시나리오

```
결과 화면(역 3회 변경) → 루트 상세(탭 2회, 역 2회) → 지도에서 보기
→ 주변 둘러보기(역 2회, 카테고리 2회) → 장소 상세(역 1회 변경)
```

이후 뒤로가기 연타 시 `주변 둘러보기 → 결과 화면 → 진입 이전 화면` 순으로 4회 이내 탈출하면 성공. 전 과정에서 document 리로드가 없어야 합니다.

## 알려진 한계 (의도된 트레이드오프)

"지도에서 보기" 같은 **복귀 버튼의 replace는 현재 스택 항목만 교체**하므로, 복귀 버튼을 경유한 경우 결과 화면이 스택에 최대 2번 남을 수 있습니다(뒤로가기 1회 추가). History API가 pop+replace를 원자적으로 지원하지 않는 한계로, 핵심 목표(클릭 이력 되감기 제거)에는 영향이 없습니다. 완전 제거가 필요하면 `navigate(-1)` + stationId 핸드오프 방식으로 후속 개선 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated station, place, and nearby-location navigation for smoother in-app transitions.
  * Preserved existing query parameters when moving between nearby locations and facility details.
  * Prevented routine selections, tab changes, and back actions from adding unnecessary browser history entries.
  * Improved navigation when viewing maps, returning to recommended stations, or recovering from unavailable place details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->