### PR TITLE
feat: 검색 색인을 위한 SEO 기본 설정 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,14 +9,19 @@
       name="description"
       content="모임 일정과 장소를 쉽고 빠르게 정하는 모여락"
     />
+    <link rel="canonical" href="https://moyeorak.site/" />
 
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://moyeorak.site/" />
     <meta property="og:title" content="모여락 | 모임 일정·장소 조율" />
     <meta
       property="og:description"
       content="모임 일정과 장소를 쉽고 빠르게 정하는 모여락"
     />
-    <meta property="og:image" content="%BASE_URL%static/images/share.png" />
+    <meta
+      property="og:image"
+      content="https://moyeorak.site/static/images/share.png"
+    />
     <meta property="og:image:alt" content="모여락 | 모임 일정·장소 조율" />
 
     <meta name="twitter:card" content="summary_large_image" />
@@ -25,7 +30,10 @@
       name="twitter:description"
       content="모임 일정과 장소를 쉽고 빠르게 정하는 모여락"
     />
-    <meta name="twitter:image" content="%BASE_URL%static/images/share.png" />
+    <meta
+      name="twitter:image"
+      content="https://moyeorak.site/static/images/share.png"
+    />
 
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+https://:version.:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+/new/*
+  X-Robots-Tag: noindex, nofollow
+
+/meetings/*
+  X-Robots-Tag: noindex, nofollow

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /new/
+Disallow: /meetings/
+
+Sitemap: https://moyeorak.site/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://moyeorak.site/</loc>
+  </url>
+</urlset>

--- a/src/seo-static.test.ts
+++ b/src/seo-static.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const siteUrl = "https://moyeorak.site";
+
+function readProjectFile(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+function expectMetaTag(html: string, attributes: string[]) {
+  const pattern = attributes
+    .map((attribute) => attribute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("[\\s\\S]*");
+
+  expect(html).toMatch(new RegExp(`<meta[\\s\\S]*${pattern}[\\s\\S]*/>`));
+}
+
+describe("SEO static configuration", () => {
+  it("declares the production URL and absolute share image URLs in index.html", () => {
+    const indexHtml = readProjectFile("index.html");
+
+    expect(indexHtml).toContain(`<link rel="canonical" href="${siteUrl}/" />`);
+    expectMetaTag(indexHtml, [`property="og:url"`, `content="${siteUrl}/"`]);
+    expectMetaTag(indexHtml, [
+      `property="og:image"`,
+      `content="${siteUrl}/static/images/share.png"`,
+    ]);
+    expectMetaTag(indexHtml, [
+      `name="twitter:image"`,
+      `content="${siteUrl}/static/images/share.png"`,
+    ]);
+  });
+
+  it("allows the public landing page and points crawlers to the sitemap", () => {
+    const robotsTxt = readProjectFile("public/robots.txt");
+
+    expect(robotsTxt).toContain("User-agent: *");
+    expect(robotsTxt).toContain("Allow: /");
+    expect(robotsTxt).toContain("Disallow: /new/");
+    expect(robotsTxt).toContain("Disallow: /meetings/");
+    expect(robotsTxt).toContain(`Sitemap: ${siteUrl}/sitemap.xml`);
+  });
+
+  it("publishes only the landing page in the sitemap", () => {
+    const sitemapXml = readProjectFile("public/sitemap.xml");
+
+    expect(sitemapXml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(sitemapXml).toContain(`<loc>${siteUrl}/</loc>`);
+    expect(sitemapXml).not.toContain("/new/");
+    expect(sitemapXml).not.toContain("/meetings/");
+  });
+
+  it("marks Cloudflare preview and app flow routes as noindex", () => {
+    const headers = readProjectFile("public/_headers");
+
+    expect(headers).toContain("https://:project.pages.dev/*");
+    expect(headers).toContain("https://:version.:project.pages.dev/*");
+    expect(headers).toContain("/new/*");
+    expect(headers).toContain("/meetings/*");
+    expect(headers).toContain("X-Robots-Tag: noindex");
+    expect(headers).toContain("X-Robots-Tag: noindex, nofollow");
+  });
+});


### PR DESCRIPTION
## 변경 사항

- 공개 랜딩 URL 기준 canonical, `og:url`, 절대 URL 공유 이미지 메타를 추가했습니다.
- `robots.txt`와 `sitemap.xml`을 추가해 검색엔진이 `/`만 색인 대상으로 인식하도록 했습니다.
- Cloudflare Pages `_headers`를 추가해 `*.pages.dev` preview와 `/new/*`, `/meetings/*` 앱 플로우에 `X-Robots-Tag: noindex`를 적용했습니다.
- SEO 정적 설정 회귀 테스트를 추가했습니다.

## 의도

모여락 서비스가 검색엔진에 발견될 수 있도록 기본 색인 신호를 제공하되, 모임 생성/초대/참가자 화면은 검색 결과에 노출되지 않도록 범위를 분리했습니다.

## 검증

- `pnpm check`
- `pnpm build`
- `pnpm vitest run` - 42 files, 112 tests passed

## 배포 후 운영 작업

- Google Search Console에 `https://moyeorak.site/sitemap.xml` 제출
- Naver Search Advisor에 사이트 등록/소유확인 후 sitemap 제출
- Bing Webmaster Tools에 sitemap 제출