### PR TITLE
fix: 출발지 대리 추가 시 participantId 전송 및 localStorageKey 정책 정리

### DIFF
--- a/src/domains/location/apis/location-api.ts
+++ b/src/domains/location/apis/location-api.ts
@@ -16,6 +16,7 @@ interface CreateLocationVoteRequestBody {
   departureLocation: string;
   localStorageKey?: string;
   meetingId: string;
+  participantId?: number;
   participantName: string;
 }
 

--- a/src/domains/location/hooks/use-create-departure-form.ts
+++ b/src/domains/location/hooks/use-create-departure-form.ts
@@ -6,12 +6,20 @@ import { z } from "zod";
 import { useCreateDeparture } from "@/domains/location/hooks/use-create-departure";
 import { getDeparturesQueryKey } from "@/domains/location/hooks/use-get-departures";
 import { getMidpointRecommendationsQueryKey } from "@/domains/location/hooks/use-get-midpoint-recommendations";
-import type { CreateLocationVoteRequest } from "@/domains/location/types/location-api-types";
+import {
+  buildCreateDepartureRequest,
+  DUPLICATE_DEPARTURE_MESSAGE,
+  isDuplicateDepartureError,
+} from "@/domains/location/utils/create-departure-request";
 import {
   isOutOfServiceAreaError,
   isWithinServiceArea,
   OUT_OF_SERVICE_AREA_MESSAGE,
 } from "@/domains/location/utils/service-area";
+import {
+  getMyParticipantQueryKey,
+  useGetMyParticipant,
+} from "@/domains/schedule/hooks/use-get-my-participant";
 import { toast } from "@/shared/components/toast";
 import { getGuestId } from "@/shared/utils/auth";
 
@@ -63,6 +71,7 @@ export function useCreateDepartureForm(
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const createDepartureMutation = useCreateDeparture();
+  const { data: myInfo } = useGetMyParticipant({ meetingId });
 
   const {
     control,
@@ -85,16 +94,18 @@ export function useCreateDepartureForm(
 
   const onSubmit = handleSubmit(async (data) => {
     try {
-      const localStorageKey = getGuestId();
+      const guestId = getGuestId();
 
-      const requestPayload: CreateLocationVoteRequest = {
+      const requestPayload = buildCreateDepartureRequest({
         meetingId: data.meetingId,
-        localStorageKey: localStorageKey || undefined,
+        participantId: data.participantId,
         participantName: data.participantName || "",
         departureLocation: data.departureLocation,
         departureLat: data.departureLat,
         departureLng: data.departureLng,
-      };
+        guestId,
+        hasMyLocationVote: myInfo?.locationVoteId != null,
+      });
 
       await createDepartureMutation.mutateAsync(requestPayload);
 
@@ -105,6 +116,12 @@ export function useCreateDepartureForm(
         queryClient.invalidateQueries({
           queryKey: getMidpointRecommendationsQueryKey({ meetingId }),
         }),
+        queryClient.invalidateQueries({
+          queryKey: getMyParticipantQueryKey({
+            localStorageKey: guestId,
+            meetingId,
+          }),
+        }),
       ]);
 
       toast.success("출발지가 추가되었어요");
@@ -113,6 +130,10 @@ export function useCreateDepartureForm(
       console.error("출발지 추가 실패:", error);
       if (isOutOfServiceAreaError(error)) {
         toast.error(OUT_OF_SERVICE_AREA_MESSAGE);
+        return;
+      }
+      if (isDuplicateDepartureError(error)) {
+        toast.error(DUPLICATE_DEPARTURE_MESSAGE);
         return;
       }
       toast.error("출발지 추가에 실패했어요. 잠시 후 다시 시도해주세요.");

--- a/src/domains/location/types/location-api-types.ts
+++ b/src/domains/location/types/location-api-types.ts
@@ -6,6 +6,8 @@ export interface CreateLocationVoteRequest {
   departureLocation: string;
   localStorageKey?: string;
   meetingId: string;
+  /** 출발지를 연결할 기존 참여자 ID (대리 추가 시 지정) */
+  participantId?: number;
   participantName: string;
 }
 

--- a/src/domains/location/utils/create-departure-request.test.ts
+++ b/src/domains/location/utils/create-departure-request.test.ts
@@ -1,0 +1,96 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import { describe, expect, it } from "vitest";
+import {
+  buildCreateDepartureRequest,
+  isDuplicateDepartureError,
+} from "@/domains/location/utils/create-departure-request";
+
+const baseParams = {
+  departureLat: "37.5145430",
+  departureLng: "127.1058860",
+  departureLocation: "서울시 송파구",
+  guestId: "guest-uuid-123",
+  hasMyLocationVote: false,
+  meetingId: "meeting-abc",
+  participantName: "친구",
+};
+
+function createAxiosError(code: string, status = 409) {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError("Request failed", "ERR_BAD_REQUEST", config, null, {
+    config,
+    data: { code },
+    headers: {},
+    status,
+    statusText: "Conflict",
+  });
+}
+
+describe("buildCreateDepartureRequest", () => {
+  it("기존 참여자를 선택하면 participantId를 숫자로 담고 localStorageKey는 보내지 않는다", () => {
+    const request = buildCreateDepartureRequest({
+      ...baseParams,
+      participantId: "10",
+    });
+
+    expect(request.participantId).toBe(10);
+    expect(request.localStorageKey).toBeUndefined();
+  });
+
+  it("참여자 미선택 + 내 출발지가 이미 있으면 대리 추가로 localStorageKey 없이 보낸다", () => {
+    const request = buildCreateDepartureRequest({
+      ...baseParams,
+      hasMyLocationVote: true,
+    });
+
+    expect(request.participantId).toBeUndefined();
+    expect(request.localStorageKey).toBeUndefined();
+  });
+
+  it("참여자 미선택 + 내 출발지가 없으면 본인 등록으로 localStorageKey를 보낸다", () => {
+    const request = buildCreateDepartureRequest(baseParams);
+
+    expect(request.participantId).toBeUndefined();
+    expect(request.localStorageKey).toBe("guest-uuid-123");
+  });
+
+  it("participantId가 빈 문자열이면 미선택으로 처리한다", () => {
+    const request = buildCreateDepartureRequest({
+      ...baseParams,
+      participantId: "",
+    });
+
+    expect(request.participantId).toBeUndefined();
+    expect(request.localStorageKey).toBe("guest-uuid-123");
+  });
+
+  it("공통 필드(meetingId, 이름, 출발지 정보)를 그대로 담는다", () => {
+    const request = buildCreateDepartureRequest(baseParams);
+
+    expect(request.meetingId).toBe("meeting-abc");
+    expect(request.participantName).toBe("친구");
+    expect(request.departureLocation).toBe("서울시 송파구");
+    expect(request.departureLat).toBe("37.5145430");
+    expect(request.departureLng).toBe("127.1058860");
+  });
+});
+
+describe("isDuplicateDepartureError", () => {
+  it("E413(localStorageKey 중복) 응답이면 true", () => {
+    expect(isDuplicateDepartureError(createAxiosError("E413"))).toBe(true);
+  });
+
+  it("E430(참여자 출발지 중복) 응답이면 true", () => {
+    expect(isDuplicateDepartureError(createAxiosError("E430"))).toBe(true);
+  });
+
+  it("다른 에러 코드면 false", () => {
+    expect(isDuplicateDepartureError(createAxiosError("E410", 404))).toBe(
+      false,
+    );
+  });
+
+  it("Axios 에러가 아니면 false", () => {
+    expect(isDuplicateDepartureError(new Error("boom"))).toBe(false);
+  });
+});

--- a/src/domains/location/utils/create-departure-request.ts
+++ b/src/domains/location/utils/create-departure-request.ts
@@ -1,0 +1,61 @@
+import axios from "axios";
+import type { CreateLocationVoteRequest } from "@/domains/location/types/location-api-types";
+
+// 백엔드 createLocationVote의 중복 등록 에러 코드
+// E413: localStorageKey 중복(이미 참여한 사용자), E430: 지정한 참여자가 이미 출발지 등록
+const DUPLICATE_DEPARTURE_ERROR_CODES = ["E413", "E430"];
+
+export const DUPLICATE_DEPARTURE_MESSAGE = "이미 출발지를 등록한 참여자예요";
+
+interface BuildCreateDepartureRequestParams {
+  departureLat: string;
+  departureLng: string;
+  departureLocation: string;
+  guestId: string;
+  hasMyLocationVote: boolean;
+  meetingId: string;
+  participantId?: string;
+  participantName: string;
+}
+
+/**
+ * 백엔드 분기 규약에 맞춰 출발지 추가 payload를 구성한다.
+ * - participantId 지정: 해당 참여자에게 투표 연결 (대리/본인 선택 등록)
+ * - 미지정 + 내 출발지 있음: 참가자 미연결 수동 추가 (localStorageKey 생략)
+ * - 미지정 + 내 출발지 없음: 본인 첫 등록 (localStorageKey 전송)
+ */
+export function buildCreateDepartureRequest({
+  departureLat,
+  departureLng,
+  departureLocation,
+  guestId,
+  hasMyLocationVote,
+  meetingId,
+  participantId,
+  participantName,
+}: BuildCreateDepartureRequestParams): CreateLocationVoteRequest {
+  const base: CreateLocationVoteRequest = {
+    departureLat,
+    departureLng,
+    departureLocation,
+    meetingId,
+    participantName,
+  };
+
+  if (participantId) {
+    return { ...base, participantId: Number(participantId) };
+  }
+
+  if (hasMyLocationVote) {
+    return base;
+  }
+
+  return { ...base, localStorageKey: guestId };
+}
+
+export function isDuplicateDepartureError(error: unknown) {
+  return (
+    axios.isAxiosError<{ code?: string }>(error) &&
+    DUPLICATE_DEPARTURE_ERROR_CODES.includes(error.response?.data?.code ?? "")
+  );
+}


### PR DESCRIPTION
## Summary

- 출발지 추가 payload 구성 로직을 순수 함수 `buildCreateDepartureRequest`로 추출하고 백엔드 분기 규약에 맞췄습니다. (closed #129)
  - 참가자 Select에서 선택한 `participantId`를 요청에 포함합니다. (기존에는 폼에만 있고 미전송이라 대리 추가가 `DUPLICATE_LOCAL_STORAGE_KEY`로 실패)
  - 참여자 미선택 + 내 출발지가 이미 있으면: 대리 수동 추가로 `localStorageKey`를 생략합니다.
  - 참여자 미선택 + 내 출발지가 없으면: 본인 첫 등록으로 `localStorageKey`를 전송합니다.
- 중복 등록(E413/E430) 응답 시 "이미 출발지를 등록한 참여자예요" 전용 토스트를 표시합니다.
- 등록 성공 시 내 참여자 정보(`participants/me`) 쿼리를 무효화해 `locationVoteId` 상태를 갱신합니다.
- 유틸 테스트 9개 추가 (`create-departure-request.test.ts`). `tsc`/`biome`/`vitest` 전체 통과.

## Screenshots

| as-is | to-be |
| - | - |
| 방장이 두 번째(다른 사람) 출발지 추가 시 일반 실패 토스트 | participantId 지정/키 생략으로 정상 등록, 중복 시 전용 안내 |

## References

- closed #129
- 백엔드 대응 PR: dnd-side-project/dnd-14th-8-backend#144 이슈 기반 — `participantId` 지원 및 방장 제한 완화 (E430 추가)
- 백엔드 분기 규약: `LocationVoteServiceImpl.createLocationVote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
