### PR TITLE
feat: 구글 사이트 소유권 확인 메타 태그 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,10 @@
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/favicon-180.png" />
+    <meta
+      name="google-site-verification"
+      content="0MBoLHQrm5dhzHH8YWnXyMHLRjlqk9Gx19XLQQL5Yys"
+    />
     <link rel="manifest" href="/manifest.webmanifest" />
   </head>
   <body>


### PR DESCRIPTION
## 변경 사항

- Google Search Console HTML 태그 방식 소유권 확인을 위한 `google-site-verification` 메타 태그를 `index.html`에 추가했습니다.

## 의도

배포 후 `https://moyeorak.site/`의 HTML head에서 Google 인증 메타를 확인할 수 있게 합니다.

## 검증

- `pnpm check`
- `pnpm build`
- `rg -n "google-site-verification|0MBoLHQ" index.html dist/index.html`