### PR TITLE
feat: 주변 장소 플로팅 버튼 개선

### DIFF
--- a/src/domains/location/components/nearby-places-floating-button/index.test.tsx
+++ b/src/domains/location/components/nearby-places-floating-button/index.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { NearbyPlacesFloatingButton } from "@/domains/location/components/nearby-places-floating-button";
+
+vi.mock("@/assets/icons/search.svg?react", () => ({
+  default: ({ className }: { className?: string }) => (
+    <svg aria-hidden="true" className={className} />
+  ),
+}));
+
+describe("NearbyPlacesFloatingButton", () => {
+  it("renders as a compact secondary map action with an accessible label", () => {
+    const markup = renderToStaticMarkup(
+      <NearbyPlacesFloatingButton onClick={() => undefined} />,
+    );
+
+    expect(markup).toContain('aria-label="선택한 역 주변 장소 둘러보기"');
+    expect(markup).toContain("주변 장소");
+    expect(markup).toContain("h-10");
+    expect(markup).toContain("rounded-full");
+  });
+});

--- a/src/domains/location/components/nearby-places-floating-button/index.tsx
+++ b/src/domains/location/components/nearby-places-floating-button/index.tsx
@@ -1,0 +1,30 @@
+import type { ButtonHTMLAttributes } from "react";
+import { SearchIcon } from "@/shared/components/icons";
+import { cn } from "@/shared/utils/cn";
+
+export type NearbyPlacesFloatingButtonProps =
+  ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function NearbyPlacesFloatingButton({
+  className,
+  type = "button",
+  ...props
+}: NearbyPlacesFloatingButtonProps) {
+  return (
+    <button
+      aria-label="선택한 역 주변 장소 둘러보기"
+      className={cn(
+        "absolute top-4 right-4 z-30 inline-flex h-10 items-center justify-center gap-1.5 rounded-full",
+        "border border-primary-main/20 bg-k-5 px-3.5 text-b4 text-k-800 shadow-[0_2px_10px_rgba(0,0,0,0.18)]",
+        "transition-colors enabled:cursor-pointer enabled:active:bg-k-50 enabled:hover:bg-white",
+        "focus-visible:outline-2 focus-visible:outline-primary-main focus-visible:outline-offset-2",
+        className,
+      )}
+      type={type}
+      {...props}
+    >
+      <SearchIcon aria-hidden className="size-4 text-primary-main" />
+      <span>주변 장소</span>
+    </button>
+  );
+}

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -9,6 +9,7 @@ import PlaceholderGraphic from "@/assets/graphic/placeholder.svg?react";
 import { BottomSheet } from "@/domains/location/components/bottom-sheet";
 import { CardLocationMember } from "@/domains/location/components/card-location-member";
 import { MapMarker } from "@/domains/location/components/map-marker";
+import { NearbyPlacesFloatingButton } from "@/domains/location/components/nearby-places-floating-button";
 import { TextPin } from "@/domains/location/components/text-pin";
 import {
   LOCATION_QUERY_PARAMS,
@@ -175,13 +176,7 @@ export function LocationMainPage() {
   return (
     <>
       {selectedStation && (
-        <button
-          type="button"
-          className="absolute top-3 right-5 z-30 rounded-full bg-k-5 px-3 py-2 text-b4 text-k-700 shadow-[0_0_4px_0_rgba(0,0,0,0.25)]"
-          onClick={handleMoveNearby}
-        >
-          주변 <span className="text-primary-main underline">둘러보기</span>
-        </button>
+        <NearbyPlacesFloatingButton onClick={handleMoveNearby} />
       )}
 
       {recommendations.map((station) => (


### PR DESCRIPTION
## 변경 사항

- 추천 역 지도 화면의 `주변 둘러보기` 버튼을 `NearbyPlacesFloatingButton` 컴포넌트로 분리했습니다.
- 버튼 문구를 `주변 장소`로 줄이고 검색 아이콘, 테두리, 그림자, 포커스 스타일을 더해 보조 액션으로 더 잘 보이게 했습니다.
- 버튼의 접근 가능한 라벨과 기본 스타일을 고정하는 렌더링 테스트를 추가했습니다.

## 배경

기존 버튼은 지도 위 우상단에 작은 텍스트 pill로 떠 있어 지도, 마커, 바텀시트에 비해 눈에 잘 띄지 않았습니다. 핵심 CTA가 아닌 선택적 보조 기능이므로 위치는 유지하되 지도 컨트롤처럼 인지되도록 시각적 대비와 터치 영역을 보강했습니다.

## 검증

- `pnpm vitest run src/domains/location/components/nearby-places-floating-button/index.test.tsx`
- `pnpm check`
- `pnpm build`

참고: `pnpm build`는 기존과 동일하게 Vite chunk size warning을 출력하지만 빌드는 성공했습니다.