### PR TITLE
출발지 관리 및 중간지점 결과 데이터 자동 갱신 개선

### DIFF
--- a/src/domains/location/constants/live-query-options.test.ts
+++ b/src/domains/location/constants/live-query-options.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  LOCATION_DEPARTURE_LIST_LIVE_QUERY_OPTIONS,
+  LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS,
+} from "@/domains/location/constants/live-query-options";
+
+describe("location live query options", () => {
+  it("출발지 관리 화면은 5초 주기로 최신 출발지를 다시 조회한다", () => {
+    expect(LOCATION_DEPARTURE_LIST_LIVE_QUERY_OPTIONS).toEqual({
+      refetchInterval: 5 * 1000,
+      refetchOnReconnect: true,
+      refetchOnWindowFocus: true,
+    });
+  });
+
+  it("중간지점 결과 화면은 10초 주기로 출발지와 추천 결과를 다시 조회한다", () => {
+    expect(LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS).toEqual({
+      refetchInterval: 10 * 1000,
+      refetchOnReconnect: true,
+      refetchOnWindowFocus: true,
+    });
+  });
+});

--- a/src/domains/location/constants/live-query-options.ts
+++ b/src/domains/location/constants/live-query-options.ts
@@ -1,0 +1,17 @@
+export interface LocationLiveQueryOptions {
+  refetchInterval?: false | number;
+  refetchOnReconnect?: boolean;
+  refetchOnWindowFocus?: boolean;
+}
+
+export const LOCATION_DEPARTURE_LIST_LIVE_QUERY_OPTIONS = {
+  refetchInterval: 5 * 1000,
+  refetchOnReconnect: true,
+  refetchOnWindowFocus: true,
+} satisfies LocationLiveQueryOptions;
+
+export const LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS = {
+  refetchInterval: 10 * 1000,
+  refetchOnReconnect: true,
+  refetchOnWindowFocus: true,
+} satisfies LocationLiveQueryOptions;

--- a/src/domains/location/hooks/use-get-departures.ts
+++ b/src/domains/location/hooks/use-get-departures.ts
@@ -1,13 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { getDepartures } from "@/domains/location/apis/location-api";
+import type { LocationLiveQueryOptions } from "@/domains/location/constants/live-query-options";
 import { getApiErrorShape } from "@/shared/utils/api-error";
 
 export function getDeparturesQueryKey({ meetingId }: { meetingId: string }) {
   return ["locations", "vote", meetingId];
 }
 
-export function useGetDepartures({ meetingId }: { meetingId: string }) {
+export function useGetDepartures({
+  meetingId,
+  ...liveQueryOptions
+}: { meetingId: string } & LocationLiveQueryOptions) {
   return useQuery({
     queryKey: getDeparturesQueryKey({ meetingId }),
     queryFn: async () => {
@@ -31,5 +35,6 @@ export function useGetDepartures({ meetingId }: { meetingId: string }) {
     },
     staleTime: 30 * 1000,
     enabled: !!meetingId,
+    ...liveQueryOptions,
   });
 }

--- a/src/domains/location/hooks/use-get-midpoint-recommendations.ts
+++ b/src/domains/location/hooks/use-get-midpoint-recommendations.ts
@@ -4,6 +4,7 @@ import {
   type GetMidpointRecommendationsParams,
   getMidpointRecommendations,
 } from "@/domains/location/apis/location-api";
+import type { LocationLiveQueryOptions } from "@/domains/location/constants/live-query-options";
 import type { MidpointRecommendationResponse } from "@/domains/location/types/location-api-types";
 import type { ApiResponse } from "@/shared/utils/axios";
 
@@ -55,7 +56,8 @@ export function getMidpointRecommendationsQueryKey({
 export function useGetMidpointRecommendations({
   meetingId,
   departureTime,
-}: GetMidpointRecommendationsParams) {
+  ...liveQueryOptions
+}: GetMidpointRecommendationsParams & LocationLiveQueryOptions) {
   return useQuery({
     queryFn: async (): Promise<MidpointQueryData> => {
       try {
@@ -109,5 +111,6 @@ export function useGetMidpointRecommendations({
     }),
     staleTime: 30 * 1000,
     enabled: !!meetingId,
+    ...liveQueryOptions,
   });
 }

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -11,6 +11,7 @@ import { CardLocationMember } from "@/domains/location/components/card-location-
 import { MapMarker } from "@/domains/location/components/map-marker";
 import { NearbyPlacesFloatingButton } from "@/domains/location/components/nearby-places-floating-button";
 import { TextPin } from "@/domains/location/components/text-pin";
+import { LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS } from "@/domains/location/constants/live-query-options";
 import {
   LOCATION_QUERY_PARAMS,
   ROUTE_TAB_VALUES,
@@ -72,10 +73,14 @@ export function LocationMainPage() {
   const { mapInst, sheetHeight, setSheetHeight } =
     useOutletContext<MapPageOutletContext>();
 
-  const { data: departures } = useGetDepartures({ meetingId });
+  const { data: departures } = useGetDepartures({
+    meetingId,
+    ...LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS,
+  });
   const { data: midpoint, isLoading: isMidpointLoading } =
     useGetMidpointRecommendations({
       meetingId,
+      ...LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS,
     });
 
   const recommendations = midpoint?.recommendations ?? [];

--- a/src/domains/location/pages/meetings/[meeting-id]/location/votes/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/votes/index.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { ButtonSubStroke } from "@/domains/location/components/button-sub-stroke";
 import { DepartureItem } from "@/domains/location/components/departure-item";
+import { LOCATION_DEPARTURE_LIST_LIVE_QUERY_OPTIONS } from "@/domains/location/constants/live-query-options";
 import { useDeleteDeparture } from "@/domains/location/hooks/use-delete-departure";
 import {
   getDeparturesQueryKey,
@@ -25,7 +26,10 @@ export function DepartureListPage() {
   >(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  const { data: departures, isLoading } = useGetDepartures({ meetingId });
+  const { data: departures, isLoading } = useGetDepartures({
+    meetingId,
+    ...LOCATION_DEPARTURE_LIST_LIVE_QUERY_OPTIONS,
+  });
   const { mutate: deleteDeparture } = useDeleteDeparture();
 
   const handleGoToResult = () => {


### PR DESCRIPTION
## 요약

- 출발지 관리 화면에서 출발지 목록을 5초 주기로 자동 갱신합니다.
- 중간지점 결과 화면에서 출발지 목록과 추천 결과를 10초 주기로 자동 갱신합니다.
- 화면별 React Query live refetch 옵션을 상수로 분리하고 테스트를 추가했습니다.

## 배경

다른 참여자가 출발지를 등록, 수정, 삭제해도 현재 화면을 보고 있는 사용자는 페이지 이동이나 수동 재조회 전까지 stale 데이터를 볼 수 있었습니다. 백엔드는 출발지 변경 시 중간지점 추천 캐시를 비우지만, 클라이언트에 변경 이벤트를 push하지 않으므로 프론트에서 1차적으로 refetch 기반 최신성 개선을 적용합니다.

## 검증

- `pnpm exec biome check src/domains/location/constants/live-query-options.ts src/domains/location/constants/live-query-options.test.ts src/domains/location/hooks/use-get-departures.ts src/domains/location/hooks/use-get-midpoint-recommendations.ts src/domains/location/pages/meetings/[meeting-id]/location/votes/index.tsx src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx`
- `pnpm build`
- `pnpm vitest run --exclude '.worktrees/**'`

## 참고

- `pnpm check`와 기본 `pnpm vitest run`은 현재 로컬의 `.worktrees/` 폴더까지 스캔하면서 기존 중첩 설정/테스트 문제로 실패합니다. 이번 PR 커밋 범위에는 `.worktrees/`가 포함되지 않습니다.

Closes #135