### PR TITLE
중간지점 추천 역 중복 제거

### DIFF
--- a/src/domains/location/hooks/use-get-midpoint-recommendations.test.ts
+++ b/src/domains/location/hooks/use-get-midpoint-recommendations.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMidpointResponse } from "@/domains/location/hooks/use-get-midpoint-recommendations";
+import type {
+  MidpointRecommendationResponse,
+  StationRecommendationDto,
+} from "@/domains/location/types/location-api-types";
+
+function createRecommendation(
+  overrides: Partial<StationRecommendationDto>,
+): StationRecommendationDto {
+  return {
+    avgTransitDuration: 25,
+    distanceFromCenter: 120,
+    latitude: 37.5,
+    line: "2호선",
+    longitude: 127,
+    rank: 1,
+    routes: [],
+    stationId: 1,
+    stationName: "강남역",
+    ...overrides,
+  };
+}
+
+describe("normalizeMidpointResponse", () => {
+  it("같은 stationId의 중간지점 추천 역은 한 번만 남긴다", () => {
+    const response: MidpointRecommendationResponse = {
+      centerPoint: { latitude: 37.5, longitude: 127 },
+      departureTime: null,
+      recommendations: [
+        createRecommendation({
+          rank: 1,
+          stationId: 10,
+          stationName: "합정역",
+        }),
+        createRecommendation({
+          rank: 2,
+          stationId: 20,
+          stationName: "홍대입구역",
+        }),
+        createRecommendation({
+          rank: 3,
+          stationId: 10,
+          stationName: "합정역",
+        }),
+        createRecommendation({
+          rank: 4,
+          stationId: 30,
+          stationName: "신촌역",
+        }),
+      ],
+      registeredCount: 4,
+      totalCount: 4,
+    };
+
+    expect(normalizeMidpointResponse(response).recommendations).toEqual([
+      expect.objectContaining({ rank: 1, stationId: 10 }),
+      expect.objectContaining({ rank: 2, stationId: 20 }),
+      expect.objectContaining({ rank: 4, stationId: 30 }),
+    ]);
+  });
+
+  it("stationId가 달라도 역 이름과 좌표가 같으면 한 번만 남긴다", () => {
+    const response: MidpointRecommendationResponse = {
+      centerPoint: { latitude: 37.5, longitude: 127 },
+      departureTime: null,
+      recommendations: [
+        createRecommendation({
+          latitude: 37.556,
+          longitude: 126.923,
+          rank: 1,
+          stationId: 10,
+          stationName: "합정역",
+        }),
+        createRecommendation({
+          latitude: 37.556,
+          line: "6호선",
+          longitude: 126.923,
+          rank: 2,
+          stationId: 11,
+          stationName: "합정역",
+        }),
+        createRecommendation({
+          latitude: 37.557,
+          longitude: 126.935,
+          rank: 3,
+          stationId: 20,
+          stationName: "홍대입구역",
+        }),
+      ],
+      registeredCount: 4,
+      totalCount: 4,
+    };
+
+    expect(normalizeMidpointResponse(response).recommendations).toEqual([
+      expect.objectContaining({ rank: 1, stationId: 10 }),
+      expect.objectContaining({ rank: 3, stationId: 20 }),
+    ]);
+  });
+});

--- a/src/domains/location/hooks/use-get-midpoint-recommendations.ts
+++ b/src/domains/location/hooks/use-get-midpoint-recommendations.ts
@@ -28,15 +28,47 @@ export interface MidpointQueryData
   totalCount?: number;
 }
 
-function normalizeMidpointResponse(
+function getPhysicalStationKey(
+  recommendation: MidpointRecommendationResponse["recommendations"][number],
+) {
+  return [
+    recommendation.stationName,
+    recommendation.latitude,
+    recommendation.longitude,
+  ].join(":");
+}
+
+function dedupeRecommendations(
+  recommendations: MidpointRecommendationResponse["recommendations"],
+) {
+  const seenStationIds = new Set<number>();
+  const seenPhysicalStations = new Set<string>();
+
+  return recommendations.filter((recommendation) => {
+    const physicalStationKey = getPhysicalStationKey(recommendation);
+    if (
+      seenStationIds.has(recommendation.stationId) ||
+      seenPhysicalStations.has(physicalStationKey)
+    ) {
+      return false;
+    }
+
+    seenStationIds.add(recommendation.stationId);
+    seenPhysicalStations.add(physicalStationKey);
+    return true;
+  });
+}
+
+export function normalizeMidpointResponse(
   response: MidpointRecommendationResponse,
 ): MidpointRecommendationResponse {
-  const registeredCount =
-    response.registeredCount ?? response.recommendations.length;
+  const recommendations = dedupeRecommendations(response.recommendations);
+  const registeredCount = response.registeredCount ?? recommendations.length;
   const totalCount = response.totalCount ?? registeredCount;
 
   return {
     ...response,
+    recommendations,
     registeredCount,
     totalCount,
   };


### PR DESCRIPTION
## Summary

- 중간지점 추천 응답 normalize 단계에서 중복 역을 제거합니다.
- 동일 `stationId`가 반복되는 경우 첫 번째 추천만 유지합니다.
- `stationId`가 달라도 `stationName + latitude + longitude`가 같은 물리 역이면 중복으로 보고 제거합니다.
- 중복 제거 회귀 테스트를 추가했습니다.

## Root Cause

`useGetMidpointRecommendations`에서 API 응답의 `recommendations` 배열을 그대로 반환하고 있어, 같은 중간지점 역이 응답에 2번 이상 포함되면 역 칩, 지도 마커, 주변 장소 화면에도 그대로 중복 노출됐습니다.

## Validation

- `pnpm exec vitest run src/domains/location/hooks/use-get-midpoint-recommendations.test.ts src/domains/location/utils/create-departure-request.test.ts src/domains/location/utils/service-area.test.ts src/domains/location/components/nearby-places-floating-button/index.test.tsx`
- `pnpm check`
- `pnpm build`

Closes #133