### PR TITLE
랜딩 오늘 생성된 모임 수 표시

### DIFF
--- a/src/domains/meeting/apis/meeting-api.ts
+++ b/src/domains/meeting/apis/meeting-api.ts
@@ -2,6 +2,7 @@ import type {
   CreateMeetingRequest,
   GetMeetingScheduleResponse,
   GetMeetingScheduleVoteResultResponse,
+  LandingStatsResponse,
   UpdateMeetingRequest,
 } from "@/domains/meeting/types/meeting-api-types";
 import { type ApiResponse, api } from "@/shared/utils/axios";
@@ -20,6 +21,10 @@ export function createMeeting(payload: CreateMeetingRequest) {
 
 export function updateMeeting(payload: UpdateMeetingRequest) {
   return api.put<ApiResponse<void>>("/api/meetings", payload);
+}
+
+export function getMeetingStats() {
+  return api.get<ApiResponse<LandingStatsResponse>>("/api/meetings/stats");
 }
 
 export function getMeetingSchedules({ meetingId }: GetMeetingSchedulesParams) {

--- a/src/domains/meeting/components/landing-stats-badge/index.test.tsx
+++ b/src/domains/meeting/components/landing-stats-badge/index.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { LandingStatsBadge } from "@/domains/meeting/components/landing-stats-badge";
+
+describe("LandingStatsBadge", () => {
+  it("formats and renders today's created meeting count", () => {
+    const markup = renderToStaticMarkup(
+      <LandingStatsBadge todayCreatedMeetingCount={1234} />,
+    );
+
+    expect(markup).toContain("오늘 1,234개의 모임이 만들어졌어요");
+    expect(markup).toContain("rounded-full");
+  });
+
+  it("renders nothing when the count is zero", () => {
+    const markup = renderToStaticMarkup(
+      <LandingStatsBadge todayCreatedMeetingCount={0} />,
+    );
+
+    expect(markup).toBe("");
+  });
+});

--- a/src/domains/meeting/components/landing-stats-badge/index.tsx
+++ b/src/domains/meeting/components/landing-stats-badge/index.tsx
@@ -1,0 +1,20 @@
+interface LandingStatsBadgeProps {
+  todayCreatedMeetingCount?: number;
+}
+
+const numberFormatter = new Intl.NumberFormat("ko-KR");
+
+export function LandingStatsBadge({
+  todayCreatedMeetingCount,
+}: LandingStatsBadgeProps) {
+  if (!todayCreatedMeetingCount || todayCreatedMeetingCount <= 0) {
+    return null;
+  }
+
+  return (
+    <p className="mt-3 rounded-full bg-p-50 px-3 py-1 text-c2 text-primary-main">
+      오늘 {numberFormatter.format(todayCreatedMeetingCount)}개의 모임이
+      만들어졌어요
+    </p>
+  );
+}

--- a/src/domains/meeting/hooks/use-meeting-stats-query.ts
+++ b/src/domains/meeting/hooks/use-meeting-stats-query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMeetingStats } from "@/domains/meeting/apis/meeting-api";
+
+export function getMeetingStatsQueryKey() {
+  return ["meeting", "stats"];
+}
+
+export function useMeetingStatsQuery() {
+  return useQuery({
+    queryFn: async () => {
+      const { data } = await getMeetingStats();
+      return data.data;
+    },
+    queryKey: getMeetingStatsQueryKey(),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/domains/meeting/pages/index.tsx
+++ b/src/domains/meeting/pages/index.tsx
@@ -5,12 +5,15 @@ import {
 } from "@/assets/characters";
 import MoyeorakLogo from "@/assets/moyeorak-logo.svg?react";
 import { LandingGuideSection } from "@/domains/meeting/components/landing-guide-section";
+import { LandingStatsBadge } from "@/domains/meeting/components/landing-stats-badge";
+import { useMeetingStatsQuery } from "@/domains/meeting/hooks/use-meeting-stats-query";
 import { ChevronDownIcon } from "@/shared/components/icons";
 import { MainButton } from "@/shared/components/main-button";
 import { MobileLayout } from "@/shared/components/mobile-layout";
 
 export function LandingPage() {
   const navigate = useNavigate();
+  const { data: meetingStats } = useMeetingStatsQuery();
 
   return (
     <MobileLayout>
@@ -20,6 +23,9 @@ export function LandingPage() {
           <span className="text-b1 text-gray-750">
             모임을 더 즐겁게, 효율적으로 시작해요
           </span>
+          <LandingStatsBadge
+            todayCreatedMeetingCount={meetingStats?.todayCreatedMeetingCount}
+          />
         </div>
         <div className="flex flex-col gap-4">
           <MainButton

--- a/src/domains/meeting/types/meeting-api-types.ts
+++ b/src/domains/meeting/types/meeting-api-types.ts
@@ -10,6 +10,10 @@ export interface UpdateMeetingRequest {
   participantCount?: number;
 }
 
+export interface LandingStatsResponse {
+  todayCreatedMeetingCount: number;
+}
+
 export interface ScheduleParticipant {
   name: string;
   votedDates: string[];


### PR DESCRIPTION
## Summary

- Add a landing stats API client and React Query hook for `GET /api/meetings/stats`.
- Add `LandingStatsBadge` to show `오늘 N개의 모임이 만들어졌어요` under the landing logo.
- Hide the badge while loading, on request failure, or when the count is zero.

Closes #136

## Validation

- `pnpm vitest run src/domains/meeting/components/landing-stats-badge/index.test.tsx src/seo-static.test.ts src/domains/location/utils/create-departure-request.test.ts src/domains/location/utils/service-area.test.ts src/domains/location/components/nearby-places-floating-button/index.test.tsx`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a landing-page badge showing how many meetings were created today.
  * Meeting counts are displayed with Korean thousands formatting and are hidden when zero or unavailable.
  * Added support for retrieving and displaying up-to-date meeting statistics.

* **Tests**
  * Added coverage for formatted counts, styling, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->