### PR TITLE
feat: add main character motion

### DIFF
--- a/src/domains/meeting/pages/index.tsx
+++ b/src/domains/meeting/pages/index.tsx
@@ -27,6 +27,7 @@ export function LandingPage() {
             title="일정 조율하기"
             description={"쉽고 빠르게 일정을\n조율하세요!"}
             character={<LandingScheduleCharacter />}
+            characterMotion="float"
             characterClassName="right-[-60px] bottom-[-90px]"
             onClick={() => navigate("/new/schedule")}
           />
@@ -36,6 +37,7 @@ export function LandingPage() {
             title="중간 지점 찾기"
             description={"공평한 중간지점을\n찾아보세요!"}
             character={<LandingMidpointCharacter />}
+            characterMotion="sway"
             characterClassName="right-[-60px] bottom-[-115px]"
             onClick={() => navigate("/new/location")}
           />

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,75 @@
 @import "./color-system.css";
 
 @layer utilities {
+  @keyframes main-character-float {
+    0%,
+    100% {
+      transform: translate3d(0, 0, 0) rotate(-1deg);
+    }
+    50% {
+      transform: translate3d(0, -6px, 0) rotate(1.5deg);
+    }
+  }
+
+  @keyframes main-character-float-active {
+    0%,
+    100% {
+      transform: translate3d(0, -2px, 0) scale(1.01) rotate(-1deg);
+    }
+    50% {
+      transform: translate3d(0, -10px, 0) scale(1.04) rotate(2deg);
+    }
+  }
+
+  @keyframes main-character-sway {
+    0%,
+    100% {
+      transform: translate3d(0, 0, 0) rotate(1deg);
+    }
+    50% {
+      transform: translate3d(-5px, -4px, 0) rotate(-2deg);
+    }
+  }
+
+  @keyframes main-character-sway-active {
+    0%,
+    100% {
+      transform: translate3d(0, -1px, 0) scale(1.01) rotate(1deg);
+    }
+    50% {
+      transform: translate3d(-9px, -7px, 0) scale(1.04) rotate(-3deg);
+    }
+  }
+
+  .animate-main-character-float {
+    transform-origin: 50% 85%;
+    animation: main-character-float 3.4s ease-in-out infinite;
+    will-change: transform;
+  }
+
+  .animate-main-character-sway {
+    transform-origin: 50% 85%;
+    animation: main-character-sway 3.8s ease-in-out infinite;
+    will-change: transform;
+  }
+
+  .group:where(:hover, :active, :focus-visible) .animate-main-character-float {
+    animation: main-character-float-active 0.9s ease-in-out infinite;
+  }
+
+  .group:where(:hover, :active, :focus-visible) .animate-main-character-sway {
+    animation: main-character-sway-active 0.9s ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-main-character-float,
+    .animate-main-character-sway {
+      animation: none;
+      transform: none;
+      will-change: auto;
+    }
+  }
+
   .scrollbar-hide {
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */

--- a/src/shared/components/main-button/index.test.tsx
+++ b/src/shared/components/main-button/index.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MainButton } from "@/shared/components/main-button";
+
+describe("MainButton", () => {
+  it("adds the requested character motion class to the character wrapper", () => {
+    const markup = renderToStaticMarkup(
+      <MainButton
+        title="일정 조율하기"
+        character={<svg aria-hidden="true" />}
+        characterMotion="float"
+      />,
+    );
+
+    expect(markup).toContain("animate-main-character-float");
+  });
+});

--- a/src/shared/components/main-button/index.tsx
+++ b/src/shared/components/main-button/index.tsx
@@ -6,15 +6,25 @@ export interface MainButtonProps {
   description?: string;
   character?: ReactNode;
   characterClassName?: string;
+  characterMotion?: "float" | "sway";
   className?: string;
   onClick?: () => void;
 }
+
+const characterMotionClassNames: Record<
+  NonNullable<MainButtonProps["characterMotion"]>,
+  string
+> = {
+  float: "animate-main-character-float",
+  sway: "animate-main-character-sway",
+};
 
 export function MainButton({
   title,
   description,
   character,
   characterClassName,
+  characterMotion,
   className,
   onClick,
 }: MainButtonProps) {
@@ -24,7 +34,7 @@ export function MainButton({
       onClick={onClick}
       className={cn(
         "relative h-[160px] w-full cursor-pointer rounded-xl py-[26px] pr-[15px] pl-7 shadow-[0_3px_6px_0_#CACACA]",
-        "flex items-center justify-between overflow-hidden",
+        "group flex items-center justify-between overflow-hidden",
         className,
       )}
     >
@@ -34,7 +44,13 @@ export function MainButton({
       </div>
 
       {character && (
-        <div className={cn("absolute shrink-0 leading-0", characterClassName)}>
+        <div
+          className={cn(
+            "absolute shrink-0 leading-0",
+            characterMotion && characterMotionClassNames[characterMotion],
+            characterClassName,
+          )}
+        >
           {character}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add ambient character motion support to MainButton
- Apply distinct float and sway animations to the two landing page action buttons
- Respect prefers-reduced-motion by disabling decorative character animation
- Add a focused render test for the motion class API

## Validation
- pnpm exec vitest run src/shared/components/main-button/index.test.tsx
- pnpm exec biome check src/shared/components/main-button/index.tsx src/shared/components/main-button/index.test.tsx src/index.css src/domains/meeting/pages/index.tsx
- pnpm run build

## Notes
- Build currently emits existing Vite warnings for missing %VITE_KAKAO_API_KEY% and %VITE_NAVER_CLIENT_ID% placeholders, but exits successfully.