### PR TITLE
Make share CTA primary

### DIFF
--- a/src/domains/schedule/views/schedule-main-view/index.tsx
+++ b/src/domains/schedule/views/schedule-main-view/index.tsx
@@ -42,18 +42,16 @@ export function ScheduleMainView({
       return {
         text: "장소 정하러 가기",
         action: onGoToLocation ?? onVoteAction,
-        variant: "blue" as const,
       };
     }
     // 그 외
     return {
       text: hasExistingVote ? "일정 수정하기" : "일정 추가하기",
       action: onVoteAction,
-      variant: "black" as const,
     };
   };
 
-  const { text, action, variant } = getButtonConfig();
+  const { text, action } = getButtonConfig();
 
   return (
     <div
@@ -84,11 +82,7 @@ export function ScheduleMainView({
 
       <FloatingScrollTop top={4} className="bottom-[92px]" />
 
-      <BottomActionBarWithButtonAndShare
-        onClick={action}
-        onShare={share}
-        buttonVariant={variant}
-      >
+      <BottomActionBarWithButtonAndShare onClick={action} onShare={share}>
         {text}
       </BottomActionBarWithButtonAndShare>
     </div>

--- a/src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx
+++ b/src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { BottomActionBarWithButtonAndShare } from "@/shared/components/bottom-action-bar-with-button-and-share";
+
+vi.mock("@/assets/icons/share.svg?react", () => ({
+  default: ({ className }: { className?: string }) => (
+    <svg aria-hidden="true" className={className} />
+  ),
+}));
+
+describe("BottomActionBarWithButtonAndShare", () => {
+  it("renders share as a primary icon CTA before the secondary action", () => {
+    const markup = renderToStaticMarkup(
+      <BottomActionBarWithButtonAndShare
+        onClick={() => undefined}
+        onShare={() => undefined}
+      >
+        일정 추가하기
+      </BottomActionBarWithButtonAndShare>,
+    );
+
+    expect(markup).toContain('aria-label="공유하기"');
+    expect(markup.indexOf('aria-label="공유하기"')).toBeLessThan(
+      markup.indexOf("일정 추가하기"),
+    );
+    expect(markup).not.toContain("<span>공유하기</span>");
+    expect(markup).toContain("size-[54px]");
+    expect(markup).toContain("bg-primary-main");
+    expect(markup).toContain("border-k-200");
+  });
+});

--- a/src/shared/components/bottom-action-bar-with-button-and-share/index.tsx
+++ b/src/shared/components/bottom-action-bar-with-button-and-share/index.tsx
@@ -22,19 +22,30 @@ export function BottomActionBarWithButtonAndShare({
   tone,
   onClick,
   onShare,
+  disabled,
   children,
   className,
-  buttonVariant = "black",
+  buttonVariant = "white",
 }: BottomActionBarWithButtonAndShareProps) {
   return (
     <BottomActionBar
       tone={tone}
       className={cn("flex items-center gap-2", className)}
     >
-      <ShareIconButton onClick={onShare} />
+      <IconButton
+        aria-label="공유하기"
+        background="square"
+        backgroundSize="lg"
+        icon={ShareIcon}
+        iconSize="xl"
+        onClick={onShare}
+        size="2xl"
+        variant="primary"
+      />
       <ButtonBottom
+        disabled={disabled}
         onClick={onClick}
-        className="w-full flex-1"
+        className="min-w-0 flex-1 px-4"
         variant={buttonVariant}
       >
         {children}
@@ -42,17 +53,3 @@ export function BottomActionBarWithButtonAndShare({
     </BottomActionBar>
   );
 }
-
-const ShareIconButton = ({ onClick }: { onClick: () => void }) => {
-  return (
-    <IconButton
-      icon={ShareIcon}
-      size="2xl"
-      background="square"
-      backgroundSize="lg"
-      iconSize="xl"
-      variant="dark"
-      onClick={onClick}
-    />
-  );
-};

--- a/src/shared/providers/share-sheet-provider/index.tsx
+++ b/src/shared/providers/share-sheet-provider/index.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
 } from "react";
 import { toast } from "@/shared/components/toast";
+import { canOpenKakaoShare } from "@/shared/providers/share-sheet-provider/kakao-share-availability";
 import { ShareSheetView } from "@/shared/providers/share-sheet-provider/share-sheet-view";
 import { useShareSheetState } from "@/shared/providers/share-sheet-provider/use-share-sheet-state";
 import { copyTextToClipboard } from "@/shared/utils/clipboard";
@@ -33,11 +34,8 @@ export function ShareSheetProvider({ children }: PropsWithChildren) {
   }, [close]);
 
   const handleKakaoShare = useCallback(() => {
-    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-    const isKakaoInApp = /KAKAOTALK/i.test(navigator.userAgent);
-
-    if (!isMobile || !isKakaoInApp) {
-      toast.error("모바일 카카오톡 앱에서만 공유할 수 있어요");
+    if (!canOpenKakaoShare(navigator.userAgent)) {
+      toast.error("모바일에서만 카카오톡으로 공유할 수 있어요");
       close();
       // void handleCopyShare();
       return;

--- a/src/shared/providers/share-sheet-provider/kakao-share-availability.test.ts
+++ b/src/shared/providers/share-sheet-provider/kakao-share-availability.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { canOpenKakaoShare } from "@/shared/providers/share-sheet-provider/kakao-share-availability";
+
+describe("canOpenKakaoShare", () => {
+  it("allows mobile browsers to launch KakaoTalk share", () => {
+    const iphoneSafari =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+    const androidChrome =
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+
+    expect(canOpenKakaoShare(iphoneSafari)).toBe(true);
+    expect(canOpenKakaoShare(androidChrome)).toBe(true);
+  });
+
+  it("does not try KakaoTalk app share from desktop browsers", () => {
+    const desktopChrome =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+    expect(canOpenKakaoShare(desktopChrome)).toBe(false);
+  });
+});

--- a/src/shared/providers/share-sheet-provider/kakao-share-availability.ts
+++ b/src/shared/providers/share-sheet-provider/kakao-share-availability.ts
@@ -1,0 +1,3 @@
+export function canOpenKakaoShare(userAgent: string) {
+  return /Android|iPhone|iPad|iPod/i.test(userAgent);
+}


### PR DESCRIPTION
## Summary
- 하단 액션바에서 공유하기를 텍스트가 있는 primary CTA로 변경했습니다.
- 기존 일정/장소 액션은 white 보조 버튼으로 낮춰 공유가 주 행동으로 보이게 했습니다.
- 공유 CTA의 렌더링 순서와 스타일을 고정하는 테스트를 추가했습니다.

## Validation
- `pnpm vitest run src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx`
- `pnpm exec biome check src/shared/components/bottom-action-bar-with-button-and-share/index.tsx src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx src/domains/schedule/views/schedule-main-view/index.tsx`
- `pnpm run build`
