### PR TITLE
근거리 출발지 중간지점 결과 안내 UX 추가

### DIFF
--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -25,6 +25,7 @@ import {
   formatDepartureDateTime,
   formatDuration,
 } from "@/domains/location/utils/format";
+import { isNearbyDepartureResult } from "@/domains/location/utils/midpoint-result";
 import { BottomActionBarWithButtonAndShare } from "@/shared/components/bottom-action-bar-with-button-and-share";
 import { ChipButton } from "@/shared/components/chip-button";
 import {
@@ -149,6 +150,9 @@ export function LocationMainPage() {
   const registeredCount = midpoint?.registeredCount ?? departureCount;
   const totalCount = midpoint?.totalCount ?? departureCount;
   const hasEnoughDepartures = registeredCount >= 2;
+  const isNearbyDepartures =
+    midpoint?.resultType === "NEARBY_DEPARTURES" ||
+    (!midpoint?.resultType && isNearbyDepartureResult(recommendations));
 
   const handleStationClick = (stationId: number) => {
     const next = new URLSearchParams(searchParams);
@@ -234,17 +238,32 @@ export function LocationMainPage() {
               ))}
             </div>
 
+            {isNearbyDepartures && (
+              <div className="rounded-lg border border-primary-main/20 bg-p-50 px-4 py-3">
+                <p className="text-primary-main text-t2">
+                  이미 가까운 위치에 있어요
+                </p>
+                <p className="mt-1 text-b4 text-k-600">
+                  이동 시간이 거의 비슷해서 편한 역을 골라도 괜찮아요.
+                </p>
+              </div>
+            )}
+
             <div className="flex items-end justify-between gap-3">
               <div>
                 <p className="text-h2 text-k-800">
                   {selectedStation.stationName}
                 </p>
-                <p className="mt-0.5 text-h1 text-k-900">
-                  평균{" "}
-                  {formatDuration(
-                    Math.round(selectedStation.avgTransitDuration),
-                  )}
-                </p>
+                {isNearbyDepartures ? (
+                  <p className="mt-0.5 text-h1 text-k-900">가까운 후보예요</p>
+                ) : (
+                  <p className="mt-0.5 text-h1 text-k-900">
+                    평균{" "}
+                    {formatDuration(
+                      Math.round(selectedStation.avgTransitDuration),
+                    )}
+                  </p>
+                )}
               </div>
 
               <button
@@ -257,8 +276,9 @@ export function LocationMainPage() {
             </div>
 
             <p className="text-b4 text-k-400">
-              {selectedStation.line} · 중심에서{" "}
-              {selectedStation.distanceFromCenter}m
+              {isNearbyDepartures
+                ? "출발지가 서로 가까워 이동 시간이 거의 비슷해요"
+                : `${selectedStation.line} · 중심에서 ${selectedStation.distanceFromCenter}m`}
             </p>
 
             <p className="inline-flex items-center gap-1 text-b3 text-k-500">

--- a/src/domains/location/types/location-api-types.ts
+++ b/src/domains/location/types/location-api-types.ts
@@ -57,9 +57,12 @@ export interface StationRecommendationDto {
   stationName: string;
 }
 
+export type MidpointResultType = "NORMAL" | "NEARBY_DEPARTURES";
+
 export interface MidpointRecommendationResponse {
   centerPoint: CenterPointDto;
   departureTime?: string | null;
+  resultType?: MidpointResultType;
   registeredCount: number;
   totalCount: number;
   recommendations: StationRecommendationDto[];

--- a/src/domains/location/utils/midpoint-result.test.ts
+++ b/src/domains/location/utils/midpoint-result.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { StationRecommendationDto } from "@/domains/location/types/location-api-types";
+import { isNearbyDepartureResult } from "@/domains/location/utils/midpoint-result";
+
+function createRecommendation(
+  overrides: Partial<StationRecommendationDto>,
+): StationRecommendationDto {
+  return {
+    avgTransitDuration: 10,
+    distanceFromCenter: 100,
+    latitude: 37.5,
+    line: "2호선",
+    longitude: 127,
+    rank: 1,
+    routes: [
+      {
+        departureAddress: "합정역",
+        departureName: "참가자A",
+        drivingDistance: 1500,
+        drivingDuration: 8,
+        drivingReachable: true,
+        participantId: 1,
+        transitDistance: 1000,
+        transitDuration: 8,
+        transitReachable: true,
+      },
+      {
+        departureAddress: "홍대입구역",
+        departureName: "참가자B",
+        drivingDistance: 1300,
+        drivingDuration: 7,
+        drivingReachable: true,
+        participantId: 2,
+        transitDistance: 900,
+        transitDuration: 9,
+        transitReachable: true,
+      },
+    ],
+    stationId: 1,
+    stationName: "합정역",
+    ...overrides,
+  };
+}
+
+describe("isNearbyDepartureResult", () => {
+  it("상위 추천 후보들의 평균 시간이 5분 이하 차이고 1순위 모든 경로가 15분 이하면 true를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({ avgTransitDuration: 8.5, rank: 1 }),
+      createRecommendation({ avgTransitDuration: 10, rank: 2, stationId: 2 }),
+      createRecommendation({ avgTransitDuration: 12, rank: 3, stationId: 3 }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations)).toBe(true);
+  });
+
+  it("추천 후보가 하나뿐이면 false를 반환한다", () => {
+    expect(isNearbyDepartureResult([createRecommendation({})])).toBe(false);
+  });
+
+  it("1순위 경로 중 하나라도 도달 불가이면 false를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({
+        routes: [
+          {
+            departureAddress: "합정역",
+            departureName: "참가자A",
+            drivingDistance: 1500,
+            drivingDuration: 8,
+            participantId: 1,
+            transitDistance: 1000,
+            transitDuration: 8,
+            transitReachable: true,
+          },
+          {
+            departureAddress: "독도",
+            departureName: "참가자B",
+            drivingDistance: 0,
+            drivingDuration: 999,
+            participantId: 2,
+            transitDistance: 0,
+            transitDuration: 999,
+            transitReachable: false,
+          },
+        ],
+      }),
+      createRecommendation({ avgTransitDuration: 10, rank: 2, stationId: 2 }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations)).toBe(false);
+  });
+
+  it("1순위 경로가 비어 있으면 false를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({ routes: [] }),
+      createRecommendation({ avgTransitDuration: 10, rank: 2, stationId: 2 }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations)).toBe(false);
+  });
+
+  it("1순위 경로 중 하나라도 15분을 초과하면 false를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({
+        routes: [
+          {
+            departureAddress: "합정역",
+            departureName: "참가자A",
+            drivingDistance: 1500,
+            drivingDuration: 8,
+            participantId: 1,
+            transitDistance: 1000,
+            transitDuration: 8,
+            transitReachable: true,
+          },
+          {
+            departureAddress: "신촌역",
+            departureName: "참가자B",
+            drivingDistance: 3000,
+            drivingDuration: 12,
+            participantId: 2,
+            transitDistance: 2600,
+            transitDuration: 16,
+            transitReachable: true,
+          },
+        ],
+      }),
+      createRecommendation({ avgTransitDuration: 10, rank: 2, stationId: 2 }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations)).toBe(false);
+  });
+
+  it("추천 후보 간 평균 시간이 5분을 초과하면 false를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({ avgTransitDuration: 8, rank: 1 }),
+      createRecommendation({ avgTransitDuration: 14, rank: 2, stationId: 2 }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations)).toBe(false);
+  });
+});

--- a/src/domains/location/utils/midpoint-result.ts
+++ b/src/domains/location/utils/midpoint-result.ts
@@ -1,0 +1,29 @@
+import type { StationRecommendationDto } from "@/domains/location/types/location-api-types";
+
+const NEARBY_MAX_ROUTE_DURATION_MINUTES = 15;
+const NEARBY_MAX_AVG_DURATION_GAP_MINUTES = 5;
+
+export function isNearbyDepartureResult(
+  recommendations: StationRecommendationDto[],
+) {
+  if (recommendations.length < 2) return false;
+
+  const sorted = [...recommendations].sort((a, b) => a.rank - b.rank);
+  const topRecommendations = sorted.slice(0, 3);
+  const avgDurations = topRecommendations.map(
+    (station) => station.avgTransitDuration,
+  );
+  const avgDurationGap = Math.max(...avgDurations) - Math.min(...avgDurations);
+  const topStation = topRecommendations[0];
+  if (topStation.routes.length === 0) return false;
+
+  const allRoutesShort = topStation.routes.every(
+    (route) =>
+      route.transitReachable !== false &&
+      route.transitDuration <= NEARBY_MAX_ROUTE_DURATION_MINUTES,
+  );
+
+  return (
+    avgDurationGap <= NEARBY_MAX_AVG_DURATION_GAP_MINUTES && allRoutesShort
+  );
+}


### PR DESCRIPTION
## 변경 사항

- 중간지점 추천 응답 타입에 `resultType`을 추가했습니다.
- `NEARBY_DEPARTURES` 결과 또는 fallback 판별 결과에 따라 중간지점 결과 화면에 근거리 안내 블록을 표시합니다.
- 근거리 케이스에서는 선택 역 제목 영역을 `평균 이동시간` 중심에서 `가까운 후보예요` 문구 중심으로 분기했습니다.
- 백엔드 필드가 아직 없는 응답에서도 동작할 수 있도록 fallback 판별 유틸과 테스트를 추가했습니다.

## 배경

합정역, 홍대입구역처럼 참여자 출발지가 이미 가까운 경우에는 일반적인 중간지점 결과보다 "이미 가까우니 편한 후보역을 고르면 된다"는 안내가 더 자연스럽습니다.

## 연동

- 백엔드 PR: https://github.com/dnd-side-project/dnd-14th-8-backend/pull/149
- 백엔드가 `resultType = NEARBY_DEPARTURES`를 내려주면 해당 값을 우선 사용합니다.
- `resultType`이 없는 응답은 기존 추천 결과 데이터로 fallback 판별합니다.

Closes #141

## 검증

- `pnpm check`
- `pnpm build`
- `pnpm vitest run`
