### PR TITLE
Fix long toast wrapping

### DIFF
--- a/src/domains/location/utils/service-area.ts
+++ b/src/domains/location/utils/service-area.ts
@@ -9,7 +9,7 @@ const SERVICE_AREA = {
 };
 
 export const OUT_OF_SERVICE_AREA_MESSAGE =
-  "아직 수도권에서만 이용할 수 있어요. 수도권 내 출발지를 선택해주세요";
+  "현재는 수도권 내 출발지만 선택할 수 있어요.";
 
 export const OUT_OF_SERVICE_AREA_ERROR_CODE = "E427";
 

--- a/src/shared/components/toast/index.stories.tsx
+++ b/src/shared/components/toast/index.stories.tsx
@@ -53,6 +53,17 @@ export const Playground: Story = {
           >
             오류
           </ChipButton>
+          <ChipButton
+            size="lg"
+            variant="outlined"
+            onClick={() =>
+              toast.error("현재는 수도권 내 출발지만 선택할 수 있어요.", {
+                toasterId,
+              })
+            }
+          >
+            긴 오류
+          </ChipButton>
         </div>
 
         <div className="absolute inset-x-0 bottom-0 flex items-center gap-2 px-5 py-3">

--- a/src/shared/components/toast/index.test.tsx
+++ b/src/shared/components/toast/index.test.tsx
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { Toast } from "@/shared/components/toast";
+
+vi.mock("sonner", () => ({
+  Toaster: ({
+    toastOptions,
+  }: {
+    toastOptions?: {
+      classNames?: {
+        title?: string;
+        toast?: string;
+      };
+    };
+  }) => (
+    <div className={toastOptions?.classNames?.toast}>
+      <span className={toastOptions?.classNames?.title}>긴 토스트 메시지</span>
+    </div>
+  ),
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("Toast", () => {
+  it("allows long messages to wrap within the mobile viewport", () => {
+    const markup = renderToStaticMarkup(<Toast />);
+
+    expect(markup).toContain("whitespace-normal");
+    expect(markup).toContain("break-keep");
+    expect(markup).toContain("min-w-[min(320px,calc(100vw-40px))]");
+    expect(markup).toContain("max-w-[calc(100vw-40px)]");
+    expect(markup).toContain("text-left");
+    expect(markup).not.toContain("whitespace-nowrap");
+    expect(markup).not.toContain("text-center");
+  });
+});

--- a/src/shared/components/toast/index.tsx
+++ b/src/shared/components/toast/index.tsx
@@ -47,15 +47,21 @@ export function Toast({
             "border-none bg-k-750 text-k-300 transition-colors hover:bg-k-800 hover:text-k-100",
             toastOptions?.classNames?.closeButton,
           ),
-          content: cn("items-center gap-1", toastOptions?.classNames?.content),
+          content: cn(
+            "min-w-0 items-center gap-1",
+            toastOptions?.classNames?.content,
+          ),
           icon: cn("size-5 shrink-0", toastOptions?.classNames?.icon),
           toast: cn(
-            "cn-toast inline-flex! items-center! whitespace-nowrap! w-max! max-w-[95vw]! gap-0.5! rounded-full! px-4! py-2! text-b4! text-k-5! shadow-none!",
+            "cn-toast inline-flex! items-center! w-fit! min-w-[min(320px,calc(100vw-40px))]! max-w-[calc(100vw-40px)]! gap-2! rounded-2xl! px-4! py-3! text-b4! text-k-5! shadow-none!",
             "fixed! left-1/2! -translate-x-1/2!",
             "mb-[90px]!",
             toastOptions?.classNames?.toast,
           ),
-          title: cn("text-b4 text-k-5", toastOptions?.classNames?.title),
+          title: cn(
+            "min-w-0 whitespace-normal break-keep text-left text-b4 text-k-5 leading-[1.4]",
+            toastOptions?.classNames?.title,
+          ),
         },
       }}
       className={cn("group toaster", className)}


### PR DESCRIPTION
## What changed
- Updated shared toast layout so long messages can wrap within the mobile viewport.
- Shortened the out-of-service-area message used by midpoint location selection.
- Added a Storybook control and regression test for long toast wrapping.

## Why
The service-area error toast was too long for the previous one-line toast layout. whitespace-nowrap caused clipping, and centered wrapped text looked cramped when forced into multiple lines.

## Validation
- pnpm exec biome check src/shared/components/toast/index.tsx src/shared/components/toast/index.test.tsx src/shared/components/toast/index.stories.tsx src/domains/location/utils/service-area.ts
- pnpm exec vitest run src/domains/location/utils/service-area.test.ts src/shared/components/toast/index.test.tsx
- pnpm run build

Note: Vite still reports the existing chunk size warning during build.