### PR TITLE
근거리 중간지점 안내 UI 톤 조정

### DIFF
--- a/src/domains/location/components/nearby-departures-note/index.test.tsx
+++ b/src/domains/location/components/nearby-departures-note/index.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { NearbyDeparturesNote } from ".";
+
+describe("NearbyDeparturesNote", () => {
+  it("renders as quiet helper text without a large headline", () => {
+    const markup = renderToStaticMarkup(<NearbyDeparturesNote />);
+
+    expect(markup).toContain("가까운 출발지예요");
+    expect(markup).toContain("후보역 이동 시간이 비슷해요");
+    expect(markup).toContain("text-b4");
+    expect(markup).toContain("text-k-500");
+    expect(markup).not.toContain("가까운 후보예요");
+    expect(markup).not.toContain("text-h1");
+    expect(markup).not.toContain("bg-p-50");
+  });
+});

--- a/src/domains/location/components/nearby-departures-note/index.tsx
+++ b/src/domains/location/components/nearby-departures-note/index.tsx
@@ -1,0 +1,7 @@
+export function NearbyDeparturesNote() {
+  return (
+    <p className="text-b4 text-k-500">
+      가까운 출발지예요 · 후보역 이동 시간이 비슷해요
+    </p>
+  );
+}

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -9,6 +9,7 @@ import PlaceholderGraphic from "@/assets/graphic/placeholder.svg?react";
 import { BottomSheet } from "@/domains/location/components/bottom-sheet";
 import { CardLocationMember } from "@/domains/location/components/card-location-member";
 import { MapMarker } from "@/domains/location/components/map-marker";
+import { NearbyDeparturesNote } from "@/domains/location/components/nearby-departures-note";
 import { NearbyPlacesFloatingButton } from "@/domains/location/components/nearby-places-floating-button";
 import { TextPin } from "@/domains/location/components/text-pin";
 import { LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS } from "@/domains/location/constants/live-query-options";
@@ -238,32 +239,17 @@ export function LocationMainPage() {
               ))}
             </div>
 
-            {isNearbyDepartures && (
-              <div className="rounded-lg border border-primary-main/20 bg-p-50 px-4 py-3">
-                <p className="text-primary-main text-t2">
-                  이미 가까운 위치에 있어요
-                </p>
-                <p className="mt-1 text-b4 text-k-600">
-                  이동 시간이 거의 비슷해서 편한 역을 골라도 괜찮아요.
-                </p>
-              </div>
-            )}
-
             <div className="flex items-end justify-between gap-3">
               <div>
                 <p className="text-h2 text-k-800">
                   {selectedStation.stationName}
                 </p>
-                {isNearbyDepartures ? (
-                  <p className="mt-0.5 text-h1 text-k-900">가까운 후보예요</p>
-                ) : (
-                  <p className="mt-0.5 text-h1 text-k-900">
-                    평균{" "}
-                    {formatDuration(
-                      Math.round(selectedStation.avgTransitDuration),
-                    )}
-                  </p>
-                )}
+                <p className="mt-0.5 text-h1 text-k-900">
+                  평균{" "}
+                  {formatDuration(
+                    Math.round(selectedStation.avgTransitDuration),
+                  )}
+                </p>
               </div>
 
               <button
@@ -276,10 +262,11 @@ export function LocationMainPage() {
             </div>
 
             <p className="text-b4 text-k-400">
-              {isNearbyDepartures
-                ? "출발지가 서로 가까워 이동 시간이 거의 비슷해요"
-                : `${selectedStation.line} · 중심에서 ${selectedStation.distanceFromCenter}m`}
+              {selectedStation.line} · 중심에서{" "}
+              {selectedStation.distanceFromCenter}m
             </p>
+
+            {isNearbyDepartures && <NearbyDeparturesNote />}
 
             <p className="inline-flex items-center gap-1 text-b3 text-k-500">
               <MemberIcon className="size-4 text-k-500" />

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -26,7 +26,7 @@ import {
   formatDepartureDateTime,
   formatDuration,
 } from "@/domains/location/utils/format";
-import { isNearbyDepartureResult } from "@/domains/location/utils/midpoint-result";
+import { shouldShowNearbyDepartureNote } from "@/domains/location/utils/midpoint-result";
 import { BottomActionBarWithButtonAndShare } from "@/shared/components/bottom-action-bar-with-button-and-share";
 import { ChipButton } from "@/shared/components/chip-button";
 import {
@@ -151,10 +151,11 @@ export function LocationMainPage() {
   const registeredCount = midpoint?.registeredCount ?? departureCount;
   const totalCount = midpoint?.totalCount ?? departureCount;
   const hasEnoughDepartures = registeredCount >= 2;
-  const isNearbyDepartures =
-    midpoint?.resultType === "NEARBY_DEPARTURES" ||
-    (!midpoint?.resultType &&
-      isNearbyDepartureResult(recommendations, departures ?? []));
+  const isNearbyDepartures = shouldShowNearbyDepartureNote({
+    resultType: midpoint?.resultType,
+    recommendations,
+    departures: departures ?? [],
+  });
 
   const handleStationClick = (stationId: number) => {
     const next = new URLSearchParams(searchParams);

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -153,7 +153,8 @@ export function LocationMainPage() {
   const hasEnoughDepartures = registeredCount >= 2;
   const isNearbyDepartures =
     midpoint?.resultType === "NEARBY_DEPARTURES" ||
-    (!midpoint?.resultType && isNearbyDepartureResult(recommendations));
+    (!midpoint?.resultType &&
+      isNearbyDepartureResult(recommendations, departures ?? []));
 
   const handleStationClick = (stationId: number) => {
     const next = new URLSearchParams(searchParams);

--- a/src/domains/location/utils/midpoint-result.test.ts
+++ b/src/domains/location/utils/midpoint-result.test.ts
@@ -3,7 +3,10 @@ import type {
   LocationVote,
   StationRecommendationDto,
 } from "@/domains/location/types/location-api-types";
-import { isNearbyDepartureResult } from "@/domains/location/utils/midpoint-result";
+import {
+  isNearbyDepartureResult,
+  shouldShowNearbyDepartureNote,
+} from "@/domains/location/utils/midpoint-result";
 
 function createRecommendation(
   overrides: Partial<StationRecommendationDto>,
@@ -90,6 +93,86 @@ describe("isNearbyDepartureResult", () => {
     ];
 
     expect(isNearbyDepartureResult(recommendations, departures)).toBe(true);
+  });
+
+  it("출발지가 가까우면 1순위 경로 시간이 길어도 true를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({
+        avgTransitDuration: 20,
+        rank: 1,
+        stationName: "홍대입구역",
+        routes: [
+          {
+            departureAddress: "홍대입구역 2호선",
+            departureName: "참가자A",
+            drivingDistance: 500,
+            drivingDuration: 3,
+            drivingReachable: true,
+            participantId: 1,
+            transitDistance: 0,
+            transitDuration: 18,
+            transitReachable: true,
+          },
+          {
+            departureAddress: "홍대입구역 공항철도",
+            departureName: "참가자B",
+            drivingDistance: 500,
+            drivingDuration: 3,
+            drivingReachable: true,
+            participantId: 2,
+            transitDistance: 0,
+            transitDuration: 22,
+            transitReachable: true,
+          },
+        ],
+      }),
+    ];
+    const departures = [
+      createDeparture({
+        departureLat: 37.5572,
+        departureLng: 126.9245,
+        departureLocation: "홍대입구역 2호선",
+        locationVoteId: 1,
+      }),
+      createDeparture({
+        departureLat: 37.557,
+        departureLng: 126.9269,
+        departureLocation: "홍대입구역 공항철도",
+        locationVoteId: 2,
+        participantName: "참가자B",
+      }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations, departures)).toBe(true);
+  });
+
+  it("백엔드가 NORMAL을 내려도 출발지가 가까우면 안내 표시 대상으로 판단한다", () => {
+    const recommendations = [
+      createRecommendation({ stationName: "홍대입구역" }),
+    ];
+    const departures = [
+      createDeparture({
+        departureLat: 37.5572,
+        departureLng: 126.9245,
+        departureLocation: "홍대입구역 2호선",
+        locationVoteId: 1,
+      }),
+      createDeparture({
+        departureLat: 37.557,
+        departureLng: 126.9269,
+        departureLocation: "홍대입구역 공항철도",
+        locationVoteId: 2,
+        participantName: "참가자B",
+      }),
+    ];
+
+    expect(
+      shouldShowNearbyDepartureNote({
+        resultType: "NORMAL",
+        recommendations,
+        departures,
+      }),
+    ).toBe(true);
   });
 
   it("추천 후보가 하나뿐이면 false를 반환한다", () => {

--- a/src/domains/location/utils/midpoint-result.test.ts
+++ b/src/domains/location/utils/midpoint-result.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { StationRecommendationDto } from "@/domains/location/types/location-api-types";
+import type {
+  LocationVote,
+  StationRecommendationDto,
+} from "@/domains/location/types/location-api-types";
 import { isNearbyDepartureResult } from "@/domains/location/utils/midpoint-result";
 
 function createRecommendation(
@@ -42,6 +45,17 @@ function createRecommendation(
   };
 }
 
+function createDeparture(overrides: Partial<LocationVote>): LocationVote {
+  return {
+    departureLat: 37.5,
+    departureLng: 127,
+    departureLocation: "서울시",
+    locationVoteId: 1,
+    participantName: "참가자A",
+    ...overrides,
+  };
+}
+
 describe("isNearbyDepartureResult", () => {
   it("상위 추천 후보들의 평균 시간이 5분 이하 차이고 1순위 모든 경로가 15분 이하면 true를 반환한다", () => {
     const recommendations = [
@@ -51,6 +65,31 @@ describe("isNearbyDepartureResult", () => {
     ];
 
     expect(isNearbyDepartureResult(recommendations)).toBe(true);
+  });
+
+  it("출발지가 가까우면 추천 후보 간 평균 시간이 벌어져도 true를 반환한다", () => {
+    const recommendations = [
+      createRecommendation({ avgTransitDuration: 6.5, rank: 1 }),
+      createRecommendation({ avgTransitDuration: 9, rank: 2, stationId: 2 }),
+      createRecommendation({ avgTransitDuration: 19, rank: 3, stationId: 3 }),
+    ];
+    const departures = [
+      createDeparture({
+        departureLat: 37.5727,
+        departureLng: 127.0164,
+        departureLocation: "동묘앞역",
+        locationVoteId: 1,
+      }),
+      createDeparture({
+        departureLat: 37.5714,
+        departureLng: 127.0095,
+        departureLocation: "동대문역",
+        locationVoteId: 2,
+        participantName: "참가자B",
+      }),
+    ];
+
+    expect(isNearbyDepartureResult(recommendations, departures)).toBe(true);
   });
 
   it("추천 후보가 하나뿐이면 false를 반환한다", () => {
@@ -130,12 +169,21 @@ describe("isNearbyDepartureResult", () => {
     expect(isNearbyDepartureResult(recommendations)).toBe(false);
   });
 
-  it("추천 후보 간 평균 시간이 5분을 초과하면 false를 반환한다", () => {
+  it("출발지가 멀리 떨어져 있으면 false를 반환한다", () => {
     const recommendations = [
       createRecommendation({ avgTransitDuration: 8, rank: 1 }),
       createRecommendation({ avgTransitDuration: 14, rank: 2, stationId: 2 }),
     ];
+    const departures = [
+      createDeparture({ departureLat: 37.5, departureLng: 127 }),
+      createDeparture({
+        departureLat: 37.65,
+        departureLng: 126.77,
+        locationVoteId: 2,
+        participantName: "참가자B",
+      }),
+    ];
 
-    expect(isNearbyDepartureResult(recommendations)).toBe(false);
+    expect(isNearbyDepartureResult(recommendations, departures)).toBe(false);
   });
 });

--- a/src/domains/location/utils/midpoint-result.ts
+++ b/src/domains/location/utils/midpoint-result.ts
@@ -1,19 +1,20 @@
-import type { StationRecommendationDto } from "@/domains/location/types/location-api-types";
+import type {
+  LocationVote,
+  StationRecommendationDto,
+} from "@/domains/location/types/location-api-types";
 
 const NEARBY_MAX_ROUTE_DURATION_MINUTES = 15;
 const NEARBY_MAX_AVG_DURATION_GAP_MINUTES = 5;
+const NEARBY_MAX_DEPARTURE_DISTANCE_METERS = 2000;
 
 export function isNearbyDepartureResult(
   recommendations: StationRecommendationDto[],
+  departures: LocationVote[] = [],
 ) {
-  if (recommendations.length < 2) return false;
+  if (recommendations.length === 0) return false;
 
   const sorted = [...recommendations].sort((a, b) => a.rank - b.rank);
   const topRecommendations = sorted.slice(0, 3);
-  const avgDurations = topRecommendations.map(
-    (station) => station.avgTransitDuration,
-  );
-  const avgDurationGap = Math.max(...avgDurations) - Math.min(...avgDurations);
   const topStation = topRecommendations[0];
   if (topStation.routes.length === 0) return false;
 
@@ -23,7 +24,71 @@ export function isNearbyDepartureResult(
       route.transitDuration <= NEARBY_MAX_ROUTE_DURATION_MINUTES,
   );
 
-  return (
-    avgDurationGap <= NEARBY_MAX_AVG_DURATION_GAP_MINUTES && allRoutesShort
+  if (!allRoutesShort) return false;
+
+  if (departures.length >= 2) {
+    return areDeparturesClose(departures);
+  }
+
+  if (recommendations.length < 2) return false;
+
+  const avgDurations = topRecommendations.map(
+    (station) => station.avgTransitDuration,
   );
+  const avgDurationGap = Math.max(...avgDurations) - Math.min(...avgDurations);
+
+  return avgDurationGap <= NEARBY_MAX_AVG_DURATION_GAP_MINUTES;
+}
+
+function areDeparturesClose(departures: LocationVote[]) {
+  for (let sourceIndex = 0; sourceIndex < departures.length; sourceIndex += 1) {
+    const source = departures[sourceIndex];
+    for (
+      let targetIndex = sourceIndex + 1;
+      targetIndex < departures.length;
+      targetIndex += 1
+    ) {
+      const target = departures[targetIndex];
+      if (
+        haversineDistance(
+          source.departureLat,
+          source.departureLng,
+          target.departureLat,
+          target.departureLng,
+        ) > NEARBY_MAX_DEPARTURE_DISTANCE_METERS
+      ) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function haversineDistance(
+  sourceLat: number,
+  sourceLng: number,
+  targetLat: number,
+  targetLng: number,
+) {
+  const earthRadiusMeters = 6_371_000;
+  const sourcePhi = toRadians(sourceLat);
+  const targetPhi = toRadians(targetLat);
+  const deltaPhi = toRadians(targetLat - sourceLat);
+  const deltaLambda = toRadians(targetLng - sourceLng);
+
+  const halfChordLength =
+    Math.sin(deltaPhi / 2) * Math.sin(deltaPhi / 2) +
+    Math.cos(sourcePhi) *
+      Math.cos(targetPhi) *
+      Math.sin(deltaLambda / 2) *
+      Math.sin(deltaLambda / 2);
+  const angularDistance =
+    2 * Math.atan2(Math.sqrt(halfChordLength), Math.sqrt(1 - halfChordLength));
+
+  return earthRadiusMeters * angularDistance;
+}
+
+function toRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
 }

--- a/src/domains/location/utils/midpoint-result.ts
+++ b/src/domains/location/utils/midpoint-result.ts
@@ -1,5 +1,6 @@
 import type {
   LocationVote,
+  MidpointResultType,
   StationRecommendationDto,
 } from "@/domains/location/types/location-api-types";
 
@@ -12,6 +13,10 @@ export function isNearbyDepartureResult(
   departures: LocationVote[] = [],
 ) {
   if (recommendations.length === 0) return false;
+
+  if (departures.length >= 2) {
+    return areDeparturesClose(departures);
+  }
 
   const sorted = [...recommendations].sort((a, b) => a.rank - b.rank);
   const topRecommendations = sorted.slice(0, 3);
@@ -26,10 +31,6 @@ export function isNearbyDepartureResult(
 
   if (!allRoutesShort) return false;
 
-  if (departures.length >= 2) {
-    return areDeparturesClose(departures);
-  }
-
   if (recommendations.length < 2) return false;
 
   const avgDurations = topRecommendations.map(
@@ -38,6 +39,21 @@ export function isNearbyDepartureResult(
   const avgDurationGap = Math.max(...avgDurations) - Math.min(...avgDurations);
 
   return avgDurationGap <= NEARBY_MAX_AVG_DURATION_GAP_MINUTES;
+}
+
+export function shouldShowNearbyDepartureNote({
+  resultType,
+  recommendations,
+  departures,
+}: {
+  resultType?: MidpointResultType;
+  recommendations: StationRecommendationDto[];
+  departures: LocationVote[];
+}) {
+  return (
+    resultType === "NEARBY_DEPARTURES" ||
+    isNearbyDepartureResult(recommendations, departures)
+  );
 }
 
 function areDeparturesClose(departures: LocationVote[]) {


### PR DESCRIPTION
## 변경 내용
- 근거리 결과 안내를 큰 카드/헤드라인 대신 작은 보조 문구로 표시
- '가까운 후보예요' 문구 제거, 역명과 평균 이동시간의 정보 위계 유지
- 구버전/미배포 백엔드 응답이 NORMAL을 내려도 출발지 좌표가 가까우면 안내 표시
- 홍대입구 2호선/홍대입구 공항철도처럼 같은 복합역 근처 케이스 fallback 보정
- 관련 컴포넌트/유틸 테스트 추가

## 검증
- pnpm check
- pnpm build
- pnpm vitest run
- pnpm vitest run src/domains/location/utils/midpoint-result.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer nearby-departure guidance to station results.
  - Nearby-departure notes now consider both route recommendations and departure locations.
  - Displays average travel duration alongside station information.

- **Bug Fixes**
  - Improved detection of nearby departures, including cases where backend result classifications are incomplete or route times vary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->