### PR TITLE
Add landing contact footer

### DIFF
--- a/src/domains/meeting/pages/index.test.tsx
+++ b/src/domains/meeting/pages/index.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { LandingPage } from "@/domains/meeting/pages";
+
+vi.mock("@/domains/meeting/hooks/use-meeting-stats-query", () => ({
+  useMeetingStatsQuery: () => ({
+    data: { todayCreatedMeetingCount: 0 },
+  }),
+}));
+
+describe("LandingPage", () => {
+  it("renders the service contact email on the landing page", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("서비스 이용 중 문의나 오류가 있다면");
+    expect(markup).toContain("moyeorak.team@gmail.com");
+  });
+});

--- a/src/domains/meeting/pages/index.tsx
+++ b/src/domains/meeting/pages/index.tsx
@@ -64,6 +64,17 @@ export function LandingPage() {
       </section>
 
       <LandingGuideSection />
+
+      <footer className="px-5 pb-8 text-center text-b2 text-k-500">
+        서비스 이용 중 문의나 오류가 있다면{" "}
+        <a
+          href="mailto:moyeorak.team@gmail.com"
+          className="text-k-700 underline underline-offset-2"
+        >
+          moyeorak.team@gmail.com
+        </a>
+        으로 알려주세요.
+      </footer>
     </MobileLayout>
   );
 }


### PR DESCRIPTION
## Summary

- Add a small contact footer under the landing guide section.
- Link `moyeorak.team@gmail.com` with `mailto:` so users can report inquiries or issues directly.
- Add a landing page rendering test that verifies the contact copy and email are present.

## Validation

- `pnpm vitest run src/domains/meeting/pages/index.test.tsx`
- `pnpm exec biome check src/domains/meeting/pages/index.tsx src/domains/meeting/pages/index.test.tsx`
- `pnpm build`

## Notes

- `pnpm build` completed with existing non-fatal warnings for missing local Vite env placeholders and bundle size.
