### PR TITLE
Add Google Tag Manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Google Tag Manager -->
+    <script>
+      ((w, d, s, l, i) => {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": Date.now(), event: "gtm.js" });
+        const f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l !== "dataLayer" ? `&l=${l}` : "";
+        j.async = true;
+        j.src = `https://www.googletagmanager.com/gtm.js?id=${i}${dl}`;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-MF3K7JF2");
+    </script>
+    <!-- End Google Tag Manager -->
+
     <title>모여락 | 모임 일정·장소 조율</title>
     <meta
       name="description"
@@ -45,6 +60,17 @@
     <link rel="manifest" href="/manifest.webmanifest" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-MF3K7JF2"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <div id="root"></div>
     <script
       type="text/javascript"


### PR DESCRIPTION
## Summary

- Add the Google Tag Manager loader to index.html head.
- Add the GTM noscript fallback immediately after the opening body tag.

## Validation

- pnpm exec biome check index.html
- pnpm build

Note: the GTM snippet was adapted to satisfy the repository Biome rules while preserving the same loader behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Tag Manager integration for improved website analytics and tag management.
  * Included a fallback mechanism for environments where JavaScript is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->