### PR TITLE
외부 API 호출 통계 관리자 대시보드 (/admin)

### DIFF
--- a/src/domains/admin/apis/admin-client.ts
+++ b/src/domains/admin/apis/admin-client.ts
@@ -1,0 +1,38 @@
+import axios, { type AxiosInstance } from "axios";
+import {
+  clearAdminToken,
+  getAdminToken,
+} from "@/domains/admin/store/admin-token";
+
+/**
+ * 관리자 전용 axios 인스턴스. 모든 요청에 X-Admin-Token 헤더를 부착하고,
+ * 401 응답 시 저장된 토큰을 폐기해 로그인 폼으로 되돌아가게 한다.
+ */
+export function createAdminAxiosInstance(): AxiosInstance {
+  const instance = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    timeout: 10000,
+  });
+
+  instance.interceptors.request.use((config) => {
+    const token = getAdminToken();
+    if (token) {
+      config.headers.set("X-Admin-Token", token);
+    }
+    return config;
+  });
+
+  instance.interceptors.response.use(undefined, (error) => {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      clearAdminToken();
+    }
+    return Promise.reject(error);
+  });
+
+  return instance;
+}
+
+export const adminApi = createAdminAxiosInstance();

--- a/src/domains/admin/apis/external-api-stats-api.ts
+++ b/src/domains/admin/apis/external-api-stats-api.ts
@@ -1,0 +1,20 @@
+import { adminApi } from "@/domains/admin/apis/admin-client";
+import type {
+  ExternalApiSummaryResponse,
+  ExternalApiTrendsResponse,
+  StatsRange,
+} from "@/domains/admin/types/external-api-stats-types";
+import type { ApiResponse } from "@/shared/utils/axios";
+
+export function getExternalApiSummary() {
+  return adminApi.get<ApiResponse<ExternalApiSummaryResponse>>(
+    "/api/admin/external-api/summary",
+  );
+}
+
+export function getExternalApiTrends(range: StatsRange) {
+  return adminApi.get<ApiResponse<ExternalApiTrendsResponse>>(
+    "/api/admin/external-api/trends",
+    { params: { range } },
+  );
+}

--- a/src/domains/admin/components/admin-login-form.test.tsx
+++ b/src/domains/admin/components/admin-login-form.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AdminLoginForm } from "@/domains/admin/components/admin-login-form";
+
+describe("AdminLoginForm", () => {
+  it("renders a password token field", () => {
+    const markup = renderToStaticMarkup(<AdminLoginForm onSubmit={() => {}} />);
+
+    expect(markup).toContain("관리자 대시보드");
+    expect(markup).toContain('type="password"');
+    expect(markup).toContain("X-Admin-Token");
+  });
+
+  it("shows an error message with an alert role", () => {
+    const markup = renderToStaticMarkup(
+      <AdminLoginForm onSubmit={() => {}} error="토큰이 올바르지 않습니다." />,
+    );
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("토큰이 올바르지 않습니다.");
+  });
+});

--- a/src/domains/admin/components/admin-login-form.tsx
+++ b/src/domains/admin/components/admin-login-form.tsx
@@ -1,0 +1,60 @@
+import { type FormEvent, useState } from "react";
+
+interface AdminLoginFormProps {
+  onSubmit: (token: string) => void;
+  error?: string | null;
+}
+
+export function AdminLoginForm({ onSubmit, error }: AdminLoginFormProps) {
+  const [value, setValue] = useState("");
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = value.trim();
+    if (trimmed) {
+      onSubmit(trimmed);
+    }
+  };
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-neutral-50 px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm"
+      >
+        <h1 className="font-semibold text-lg text-neutral-900">
+          관리자 대시보드
+        </h1>
+        <p className="mt-1 text-neutral-500 text-sm">
+          외부 API 호출 통계를 보려면 관리자 토큰을 입력하세요.
+        </p>
+
+        <label className="mt-6 block font-medium text-neutral-700 text-sm">
+          관리자 토큰
+          <input
+            type="password"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            autoComplete="off"
+            className="mt-1.5 w-full rounded-lg border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-neutral-900"
+            placeholder="X-Admin-Token"
+          />
+        </label>
+
+        {error ? (
+          <p className="mt-2 text-red-600 text-sm" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!value.trim()}
+          className="mt-6 w-full rounded-lg bg-neutral-900 py-2.5 font-medium text-sm text-white transition-colors hover:bg-neutral-700 disabled:cursor-not-allowed disabled:bg-neutral-300"
+        >
+          입장
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/domains/admin/components/api-summary-card.test.tsx
+++ b/src/domains/admin/components/api-summary-card.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ApiSummaryCard } from "@/domains/admin/components/api-summary-card";
+import type { ApiSummary } from "@/domains/admin/types/external-api-stats-types";
+
+const odsay: ApiSummary = {
+  api: "odsay",
+  calls: 420,
+  success: 416,
+  failure: 4,
+  successRate: 99.0,
+  rateLimited: 37,
+  p95Ms: 840,
+  dailyQuota: 1000,
+  quotaRemaining: 580,
+  todayCostUsd: null,
+};
+
+const google: ApiSummary = {
+  api: "google_routes",
+  calls: 3540,
+  success: 3480,
+  failure: 60,
+  successRate: 98.3,
+  rateLimited: 0,
+  p95Ms: 990,
+  dailyQuota: null,
+  quotaRemaining: null,
+  todayCostUsd: 0.265,
+};
+
+describe("ApiSummaryCard", () => {
+  it("renders quota remaining and a 429 badge for a quota-limited API", () => {
+    const markup = renderToStaticMarkup(<ApiSummaryCard summary={odsay} />);
+
+    expect(markup).toContain("ODsay");
+    expect(markup).toContain("420");
+    expect(markup).toContain("99.0%");
+    expect(markup).toContain("840ms");
+    expect(markup).toContain("한도 잔여");
+    expect(markup).toContain("580");
+    expect(markup).toContain("1,000");
+    expect(markup).toContain("429");
+  });
+
+  it("renders cost instead of quota for Google and hides the 429 badge when zero", () => {
+    const markup = renderToStaticMarkup(<ApiSummaryCard summary={google} />);
+
+    expect(markup).toContain("Google Routes");
+    expect(markup).toContain("오늘 비용");
+    expect(markup).toContain("$0.265");
+    expect(markup).not.toContain("한도 잔여");
+    expect(markup).not.toContain("429 ·");
+  });
+});

--- a/src/domains/admin/components/api-summary-card.tsx
+++ b/src/domains/admin/components/api-summary-card.tsx
@@ -1,0 +1,95 @@
+import {
+  API_LABELS,
+  type ApiSummary,
+} from "@/domains/admin/types/external-api-stats-types";
+import { cn } from "@/shared/utils/cn";
+
+interface ApiSummaryCardProps {
+  summary: ApiSummary;
+}
+
+function formatNumber(value: number) {
+  return value.toLocaleString("ko-KR");
+}
+
+export function ApiSummaryCard({ summary }: ApiSummaryCardProps) {
+  const hasQuota =
+    summary.dailyQuota !== null && summary.quotaRemaining !== null;
+  const quotaUsedRatio =
+    hasQuota && summary.dailyQuota ? summary.calls / summary.dailyQuota : 0;
+  const quotaWarning = hasQuota && quotaUsedRatio >= 0.8;
+
+  const successColor =
+    summary.successRate >= 99
+      ? "text-green-600"
+      : summary.successRate >= 95
+        ? "text-amber-600"
+        : "text-red-600";
+
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-neutral-900 text-sm">
+          {API_LABELS[summary.api]}
+        </h3>
+        {summary.rateLimited > 0 ? (
+          <span className="rounded-full bg-red-50 px-2 py-0.5 font-medium text-red-600 text-xs">
+            429 · {formatNumber(summary.rateLimited)}
+          </span>
+        ) : null}
+      </div>
+
+      <dl className="mt-4 grid grid-cols-2 gap-y-3 text-sm">
+        <div>
+          <dt className="text-neutral-500">오늘 호출</dt>
+          <dd className="font-semibold text-neutral-900">
+            {formatNumber(summary.calls)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-neutral-500">성공률</dt>
+          <dd className={cn("font-semibold", successColor)}>
+            {summary.successRate.toFixed(1)}%
+          </dd>
+        </div>
+        <div>
+          <dt className="text-neutral-500">p95</dt>
+          <dd className="font-semibold text-neutral-900">
+            {Math.round(summary.p95Ms)}ms
+          </dd>
+        </div>
+        <div>
+          <dt className="text-neutral-500">실패</dt>
+          <dd className="font-semibold text-neutral-900">
+            {formatNumber(summary.failure)}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 border-neutral-100 border-t pt-3 text-sm">
+        {hasQuota ? (
+          <div className="flex items-center justify-between">
+            <span className="text-neutral-500">한도 잔여</span>
+            <span
+              className={cn(
+                "font-medium",
+                quotaWarning ? "text-red-600" : "text-neutral-900",
+              )}
+            >
+              {formatNumber(summary.quotaRemaining ?? 0)} /{" "}
+              {formatNumber(summary.dailyQuota ?? 0)}
+            </span>
+          </div>
+        ) : null}
+        {summary.todayCostUsd !== null ? (
+          <div className="flex items-center justify-between">
+            <span className="text-neutral-500">오늘 비용</span>
+            <span className="font-medium text-neutral-900">
+              ${summary.todayCostUsd.toFixed(3)}
+            </span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/domains/admin/components/range-toggle.tsx
+++ b/src/domains/admin/components/range-toggle.tsx
@@ -1,0 +1,32 @@
+import {
+  STATS_RANGES,
+  type StatsRange,
+} from "@/domains/admin/types/external-api-stats-types";
+import { cn } from "@/shared/utils/cn";
+
+interface RangeToggleProps {
+  value: StatsRange;
+  onChange: (range: StatsRange) => void;
+}
+
+export function RangeToggle({ value, onChange }: RangeToggleProps) {
+  return (
+    <div className="inline-flex rounded-lg border border-neutral-200 bg-white p-0.5">
+      {STATS_RANGES.map((range) => (
+        <button
+          key={range}
+          type="button"
+          onClick={() => onChange(range)}
+          className={cn(
+            "rounded-md px-3 py-1 font-medium text-sm transition-colors",
+            value === range
+              ? "bg-neutral-900 text-white"
+              : "text-neutral-600 hover:text-neutral-900",
+          )}
+        >
+          {range}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/domains/admin/components/trend-chart.tsx
+++ b/src/domains/admin/components/trend-chart.tsx
@@ -1,0 +1,125 @@
+export interface TrendSeries {
+  label: string;
+  color: string;
+  values: number[];
+}
+
+interface TrendChartProps {
+  title: string;
+  labels: string[];
+  series: TrendSeries[];
+  formatValue?: (value: number) => string;
+}
+
+const WIDTH = 640;
+const HEIGHT = 200;
+const PADDING = { top: 16, right: 16, bottom: 28, left: 44 };
+
+const PLOT_WIDTH = WIDTH - PADDING.left - PADDING.right;
+const PLOT_HEIGHT = HEIGHT - PADDING.top - PADDING.bottom;
+
+function xAt(index: number, count: number) {
+  if (count <= 1) return PADDING.left;
+  return PADDING.left + (PLOT_WIDTH * index) / (count - 1);
+}
+
+function yAt(value: number, max: number) {
+  if (max <= 0) return PADDING.top + PLOT_HEIGHT;
+  return PADDING.top + PLOT_HEIGHT - (PLOT_HEIGHT * value) / max;
+}
+
+export function TrendChart({
+  title,
+  labels,
+  series,
+  formatValue = (value) => value.toLocaleString("ko-KR"),
+}: TrendChartProps) {
+  const count = labels.length;
+  const max = Math.max(1, ...series.flatMap((entry) => entry.values));
+
+  const xTickIndices =
+    count <= 1 ? [0] : [0, Math.floor((count - 1) / 2), count - 1];
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-semibold text-neutral-900 text-sm">{title}</h3>
+        <ul className="flex flex-wrap gap-3">
+          {series.map((entry) => (
+            <li
+              key={entry.label}
+              className="flex items-center gap-1.5 text-neutral-600 text-xs"
+            >
+              <span
+                className="inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: entry.color }}
+              />
+              {entry.label}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-3 overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          className="h-auto w-full min-w-[480px]"
+          role="img"
+          aria-label={title}
+        >
+          <line
+            x1={PADDING.left}
+            y1={PADDING.top + PLOT_HEIGHT}
+            x2={PADDING.left + PLOT_WIDTH}
+            y2={PADDING.top + PLOT_HEIGHT}
+            stroke="#e5e5e5"
+          />
+          <text
+            x={PADDING.left - 8}
+            y={PADDING.top + 4}
+            textAnchor="end"
+            className="fill-neutral-400 text-[10px]"
+          >
+            {formatValue(max)}
+          </text>
+          <text
+            x={PADDING.left - 8}
+            y={PADDING.top + PLOT_HEIGHT}
+            textAnchor="end"
+            className="fill-neutral-400 text-[10px]"
+          >
+            0
+          </text>
+
+          {xTickIndices.map((index) => (
+            <text
+              key={index}
+              x={xAt(index, count)}
+              y={HEIGHT - 8}
+              textAnchor="middle"
+              className="fill-neutral-400 text-[10px]"
+            >
+              {labels[index]}
+            </text>
+          ))}
+
+          {series.map((entry) => (
+            <polyline
+              key={entry.label}
+              fill="none"
+              stroke={entry.color}
+              strokeWidth={2}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              points={entry.values
+                .map(
+                  (value, index) => `${xAt(index, count)},${yAt(value, max)}`,
+                )
+                .join(" ")}
+            />
+          ))}
+        </svg>
+      </div>
+    </section>
+  );
+}

--- a/src/domains/admin/constants/api-colors.ts
+++ b/src/domains/admin/constants/api-colors.ts
@@ -1,0 +1,9 @@
+import type { ExternalApiTag } from "@/domains/admin/types/external-api-stats-types";
+
+/** 차트에서 API를 구분하는 범주형 색상 (라이트 테마 기준, 접근성 고려한 명도차). */
+export const API_COLORS: Record<ExternalApiTag, string> = {
+  odsay: "#4f46e5",
+  kakao_local: "#0891b2",
+  kakao_directions: "#7c3aed",
+  google_routes: "#ea580c",
+};

--- a/src/domains/admin/hooks/use-admin-auth.ts
+++ b/src/domains/admin/hooks/use-admin-auth.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from "react";
+import {
+  clearAdminToken,
+  getAdminToken,
+  setAdminToken,
+} from "@/domains/admin/store/admin-token";
+
+export interface AdminAuth {
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+/**
+ * sessionStorage의 관리자 토큰을 React 상태와 동기화한다.
+ * 401 응답 시 admin-client 인터셉터가 sessionStorage를 비우므로, 화면에서는 logout()으로 상태를 맞춘다.
+ */
+export function useAdminAuth(): AdminAuth {
+  const [token, setToken] = useState<string | null>(() => getAdminToken());
+
+  const login = useCallback((next: string) => {
+    setAdminToken(next);
+    setToken(next);
+  }, []);
+
+  const logout = useCallback(() => {
+    clearAdminToken();
+    setToken(null);
+  }, []);
+
+  return { token, isAuthenticated: Boolean(token), login, logout };
+}

--- a/src/domains/admin/hooks/use-external-api-summary-query.ts
+++ b/src/domains/admin/hooks/use-external-api-summary-query.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getExternalApiSummary } from "@/domains/admin/apis/external-api-stats-api";
+
+export function externalApiSummaryQueryKey() {
+  return ["admin", "external-api", "summary"];
+}
+
+export function useExternalApiSummaryQuery(enabled = true) {
+  return useQuery({
+    enabled,
+    queryKey: externalApiSummaryQueryKey(),
+    queryFn: () => getExternalApiSummary().then(({ data }) => data.data),
+    refetchInterval: 60_000,
+  });
+}

--- a/src/domains/admin/hooks/use-external-api-trends-query.ts
+++ b/src/domains/admin/hooks/use-external-api-trends-query.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getExternalApiTrends } from "@/domains/admin/apis/external-api-stats-api";
+import type { StatsRange } from "@/domains/admin/types/external-api-stats-types";
+
+export function externalApiTrendsQueryKey(range: StatsRange) {
+  return ["admin", "external-api", "trends", range];
+}
+
+export function useExternalApiTrendsQuery(range: StatsRange, enabled = true) {
+  return useQuery({
+    enabled,
+    queryKey: externalApiTrendsQueryKey(range),
+    queryFn: () => getExternalApiTrends(range).then(({ data }) => data.data),
+  });
+}

--- a/src/domains/admin/pages/admin-dashboard-page.tsx
+++ b/src/domains/admin/pages/admin-dashboard-page.tsx
@@ -1,0 +1,168 @@
+import axios from "axios";
+import { format } from "date-fns";
+import { useEffect, useState } from "react";
+import { AdminLoginForm } from "@/domains/admin/components/admin-login-form";
+import { ApiSummaryCard } from "@/domains/admin/components/api-summary-card";
+import { RangeToggle } from "@/domains/admin/components/range-toggle";
+import {
+  TrendChart,
+  type TrendSeries,
+} from "@/domains/admin/components/trend-chart";
+import { API_COLORS } from "@/domains/admin/constants/api-colors";
+import { useAdminAuth } from "@/domains/admin/hooks/use-admin-auth";
+import { useExternalApiSummaryQuery } from "@/domains/admin/hooks/use-external-api-summary-query";
+import { useExternalApiTrendsQuery } from "@/domains/admin/hooks/use-external-api-trends-query";
+import {
+  API_LABELS,
+  type ApiTrend,
+  type StatsRange,
+  type TrendPoint,
+} from "@/domains/admin/types/external-api-stats-types";
+
+function isUnauthorized(error: unknown): boolean {
+  return axios.isAxiosError(error) && error.response?.status === 401;
+}
+
+function labelFormat(range: StatsRange): string {
+  return range === "24h" ? "HH:mm" : "MM/dd";
+}
+
+function toLabels(points: TrendPoint[], range: StatsRange): string[] {
+  return points.map((point) =>
+    format(new Date(point.bucketStart), labelFormat(range)),
+  );
+}
+
+function toSeries(
+  apis: ApiTrend[],
+  pick: (point: TrendPoint) => number,
+): TrendSeries[] {
+  return apis.map((trend) => ({
+    label: API_LABELS[trend.api],
+    color: API_COLORS[trend.api],
+    values: trend.points.map(pick),
+  }));
+}
+
+interface DashboardProps {
+  onUnauthorized: () => void;
+  onLogout: () => void;
+}
+
+function Dashboard({ onUnauthorized, onLogout }: DashboardProps) {
+  const [range, setRange] = useState<StatsRange>("24h");
+  const summaryQuery = useExternalApiSummaryQuery();
+  const trendsQuery = useExternalApiTrendsQuery(range);
+
+  useEffect(() => {
+    if (
+      isUnauthorized(summaryQuery.error) ||
+      isUnauthorized(trendsQuery.error)
+    ) {
+      onUnauthorized();
+    }
+  }, [summaryQuery.error, trendsQuery.error, onUnauthorized]);
+
+  const trends = trendsQuery.data;
+  const labels = trends?.apis[0] ? toLabels(trends.apis[0].points, range) : [];
+  const googleTrend = trends?.apis.find(
+    (entry) => entry.api === "google_routes",
+  );
+
+  return (
+    <div className="min-h-dvh bg-neutral-50 px-4 py-8">
+      <div className="mx-auto max-w-5xl">
+        <header className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="font-bold text-neutral-900 text-xl">
+              외부 API 호출 통계
+            </h1>
+            {summaryQuery.data ? (
+              <p className="mt-0.5 text-neutral-500 text-xs">
+                기준{" "}
+                {format(new Date(summaryQuery.data.asOf), "yyyy-MM-dd HH:mm")}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-3">
+            <RangeToggle value={range} onChange={setRange} />
+            <button
+              type="button"
+              onClick={onLogout}
+              className="rounded-lg border border-neutral-200 bg-white px-3 py-1.5 text-neutral-600 text-sm hover:text-neutral-900"
+            >
+              로그아웃
+            </button>
+          </div>
+        </header>
+
+        {summaryQuery.isLoading ? (
+          <p className="mt-10 text-center text-neutral-500 text-sm">
+            불러오는 중…
+          </p>
+        ) : null}
+
+        {summaryQuery.data ? (
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {summaryQuery.data.apis.map((summary) => (
+              <ApiSummaryCard key={summary.api} summary={summary} />
+            ))}
+          </div>
+        ) : null}
+
+        {trends && labels.length > 0 ? (
+          <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <TrendChart
+              title="호출수 추이"
+              labels={labels}
+              series={toSeries(trends.apis, (point) => point.calls)}
+            />
+            <TrendChart
+              title="에러율 추이 (%)"
+              labels={labels}
+              series={toSeries(trends.apis, (point) => point.errorRate)}
+              formatValue={(value) => `${value.toFixed(0)}%`}
+            />
+            {googleTrend ? (
+              <TrendChart
+                title="Google 비용 추이 (USD)"
+                labels={labels}
+                series={[
+                  {
+                    label: API_LABELS.google_routes,
+                    color: API_COLORS.google_routes,
+                    values: googleTrend.points.map(
+                      (point) => point.costUsd ?? 0,
+                    ),
+                  },
+                ]}
+                formatValue={(value) => `$${value.toFixed(2)}`}
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function AdminDashboardPage() {
+  const { isAuthenticated, login, logout } = useAdminAuth();
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  const handleLogin = (token: string) => {
+    setLoginError(null);
+    login(token);
+  };
+
+  const handleUnauthorized = () => {
+    setLoginError("토큰이 올바르지 않습니다. 다시 입력해주세요.");
+    logout();
+  };
+
+  if (!isAuthenticated) {
+    return <AdminLoginForm onSubmit={handleLogin} error={loginError} />;
+  }
+
+  return <Dashboard onUnauthorized={handleUnauthorized} onLogout={logout} />;
+}

--- a/src/domains/admin/store/admin-token.ts
+++ b/src/domains/admin/store/admin-token.ts
@@ -1,0 +1,16 @@
+const ADMIN_TOKEN_KEY = "admin-token";
+
+/**
+ * 관리자 토큰은 세션 한정(sessionStorage)으로만 보관한다. 탭 종료 시 만료된다.
+ */
+export function getAdminToken(): string | null {
+  return sessionStorage.getItem(ADMIN_TOKEN_KEY);
+}
+
+export function setAdminToken(token: string): void {
+  sessionStorage.setItem(ADMIN_TOKEN_KEY, token);
+}
+
+export function clearAdminToken(): void {
+  sessionStorage.removeItem(ADMIN_TOKEN_KEY);
+}

--- a/src/domains/admin/types/external-api-stats-types.ts
+++ b/src/domains/admin/types/external-api-stats-types.ts
@@ -1,0 +1,53 @@
+export type StatsRange = "24h" | "7d" | "30d";
+
+export const STATS_RANGES: StatsRange[] = ["24h", "7d", "30d"];
+
+/** 외부 API 태그 (백엔드 ExternalApi.tag()) */
+export type ExternalApiTag =
+  | "odsay"
+  | "kakao_local"
+  | "kakao_directions"
+  | "google_routes";
+
+export interface ApiSummary {
+  api: ExternalApiTag;
+  calls: number;
+  success: number;
+  failure: number;
+  successRate: number;
+  rateLimited: number;
+  p95Ms: number;
+  dailyQuota: number | null;
+  quotaRemaining: number | null;
+  todayCostUsd: number | null;
+}
+
+export interface ExternalApiSummaryResponse {
+  asOf: string;
+  apis: ApiSummary[];
+}
+
+export interface TrendPoint {
+  bucketStart: string;
+  calls: number;
+  failure: number;
+  errorRate: number;
+  costUsd: number | null;
+}
+
+export interface ApiTrend {
+  api: ExternalApiTag;
+  points: TrendPoint[];
+}
+
+export interface ExternalApiTrendsResponse {
+  range: string;
+  apis: ApiTrend[];
+}
+
+export const API_LABELS: Record<ExternalApiTag, string> = {
+  odsay: "ODsay",
+  kakao_local: "Kakao Local",
+  kakao_directions: "Kakao Directions",
+  google_routes: "Google Routes",
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,5 @@
 import { Outlet, Route, Routes } from "react-router";
+import { AdminDashboardPage } from "@/domains/admin/pages/admin-dashboard-page";
 import {
   MapDefaultPage,
   MapIndexRedirectPage,
@@ -24,6 +25,7 @@ export function CustomRoutes() {
   return (
     <Routes>
       <Route path="/" element={<LandingPage />} />
+      <Route path="/admin" element={<AdminDashboardPage />} />
       <Route path="/new/:flow" element={<NewMeetingPage />} />
 
       <Route


### PR DESCRIPTION
## 목적
백엔드 관리자 통계 API를 소비하는 `/admin` 대시보드를 추가한다. 팀 전체가 메인 도메인에서 외부 API(ODsay/Kakao/Google) 호출 통계를 SSH 터널·Grafana 없이 확인.

Closes #147
의존: dnd-side-project/dnd-14th-8-backend#157 (관리자 통계 API)

## 구성
- **인증(공유 토큰)**: `admin-token`(sessionStorage) · `admin-client`(X-Admin-Token 부착, 401 시 토큰 폐기) · `use-admin-auth`(상태 동기화) · `AdminLoginForm`
- **대시보드**: `/admin` 라우트 + 인증 게이트
  - `ApiSummaryCard`: 오늘 호출·성공률·p95·429·한도 잔여/비용, 한도 임박 경고
  - `RangeToggle`: 24h / 7d / 30d
  - `TrendChart`: **의존성 없는 인라인 SVG** 멀티라인 (호출수·에러율·Google 비용)
  - 401 시 자동 재로그인 유도
- **API/훅**: `external-api-stats-api` + react-query 훅 2종

## 설계 메모
- 차트는 라이브러리(recharts) 대신 인라인 SVG로 구현 — React 19 호환 걱정 없고 의존성 0, 내부 대시보드에 충분
- 메인 네비게이션에는 미노출(직접 URL 접근)

## 실행
`.env`에 `VITE_API_BASE_URL` 지정 후 `pnpm dev` → `/admin` → 백엔드 `ADMIN_TOKEN` 입력

## 테스트
`AdminLoginForm`·`ApiSummaryCard` 렌더 (vitest), 타입체크·biome 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin dashboard available at `/admin`.
  * Added secure admin token login with session-based authentication.
  * Added API usage summary cards showing calls, success rates, latency, failures, quotas, and costs.
  * Added trend charts with selectable 24-hour, 7-day, and 30-day ranges.
  * Dashboard data refreshes automatically and handles expired authentication sessions.

* **Tests**
  * Added coverage for admin login behavior, validation, errors, and API summary display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->