### PR TITLE
최근 모임 목록으로 내 모임 다시가기 추가

### DIFF
--- a/src/domains/meeting/apis/meeting-api.ts
+++ b/src/domains/meeting/apis/meeting-api.ts
@@ -3,6 +3,7 @@ import type {
   GetMeetingScheduleResponse,
   GetMeetingScheduleVoteResultResponse,
   LandingStatsResponse,
+  MyMeetingResponse,
   UpdateMeetingRequest,
 } from "@/domains/meeting/types/meeting-api-types";
 import { type ApiResponse, api } from "@/shared/utils/axios";
@@ -15,6 +16,10 @@ export interface GetMeetingSchedulesParams {
   meetingId: string;
 }
 
+export interface GetMyMeetingsParams {
+  localStorageKey: string;
+}
+
 export function createMeeting(payload: CreateMeetingRequest) {
   return api.post<ApiResponse<string>>("/api/meetings", payload);
 }
@@ -25,6 +30,12 @@ export function updateMeeting(payload: UpdateMeetingRequest) {
 
 export function getMeetingStats() {
   return api.get<ApiResponse<LandingStatsResponse>>("/api/meetings/stats");
+}
+
+export function getMyMeetings({ localStorageKey }: GetMyMeetingsParams) {
+  return api.get<ApiResponse<MyMeetingResponse[]>>("/api/meetings/me", {
+    params: { localStorageKey },
+  });
 }
 
 export function getMeetingSchedules({ meetingId }: GetMeetingSchedulesParams) {

--- a/src/domains/meeting/components/my-meeting-list/index.test.tsx
+++ b/src/domains/meeting/components/my-meeting-list/index.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { MyMeetingList } from "@/domains/meeting/components/my-meeting-list";
+
+describe("MyMeetingList", () => {
+  it("renders my meetings with host, role, participant count, and created date", () => {
+    const markup = renderToStaticMarkup(
+      <MyMeetingList
+        meetings={[
+          {
+            createdAt: "2026-07-23T14:10:00",
+            hostName: "민수",
+            isHost: true,
+            meetingId: "meeting-id",
+            participantCount: 4,
+          },
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("최근 모임");
+    expect(markup).toContain("민수님의 모임");
+    expect(markup).toContain("팀장 · 4명 · 7월 23일 생성");
+  });
+
+  it("renders nothing when there are no meetings", () => {
+    const markup = renderToStaticMarkup(
+      <MyMeetingList meetings={[]} onSelect={vi.fn()} />,
+    );
+
+    expect(markup).toBe("");
+  });
+});

--- a/src/domains/meeting/components/my-meeting-list/index.tsx
+++ b/src/domains/meeting/components/my-meeting-list/index.tsx
@@ -1,0 +1,54 @@
+import type { MyMeetingResponse } from "@/domains/meeting/types/meeting-api-types";
+import { ChevronRightIcon } from "@/shared/components/icons";
+
+interface MyMeetingListProps {
+  meetings: MyMeetingResponse[];
+  onSelect: (meetingId: string) => void;
+}
+
+export function MyMeetingList({ meetings, onSelect }: MyMeetingListProps) {
+  if (meetings.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-7 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-k-900 text-t2">최근 모임</h2>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {meetings.map((meeting) => (
+          <li key={meeting.meetingId}>
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-k-100 bg-k-5 px-4 py-3 text-left shadow-[0_2px_6px_0_rgba(22,22,26,0.06)] transition-colors hover:bg-k-10 focus-visible:outline-2 focus-visible:outline-primary-main focus-visible:outline-offset-2"
+              onClick={() => onSelect(meeting.meetingId)}
+            >
+              <span className="min-w-0">
+                <span className="block truncate text-k-900 text-t2">
+                  {meeting.hostName}님의 모임
+                </span>
+                <span className="mt-1 block text-b2 text-k-600">
+                  {getRoleLabel(meeting.isHost)} · {meeting.participantCount}명
+                  · {formatCreatedDate(meeting.createdAt)} 생성
+                </span>
+              </span>
+              <ChevronRightIcon className="shrink-0 text-k-500" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function getRoleLabel(isHost: boolean) {
+  return isHost ? "팀장" : "참여자";
+}
+
+function formatCreatedDate(createdAt: string) {
+  const [, month, day] = createdAt.slice(0, 10).split("-");
+
+  return `${Number(month)}월 ${Number(day)}일`;
+}

--- a/src/domains/meeting/hooks/use-my-meetings-query.ts
+++ b/src/domains/meeting/hooks/use-my-meetings-query.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyMeetings } from "@/domains/meeting/apis/meeting-api";
+import { getGuestId } from "@/shared/utils/auth";
+
+export function getMyMeetingsQueryKey(localStorageKey: string) {
+  return ["meeting", "me", localStorageKey];
+}
+
+export function useMyMeetingsQuery() {
+  const localStorageKey = getGuestId();
+
+  return useQuery({
+    queryFn: async () => {
+      const { data } = await getMyMeetings({ localStorageKey });
+      return data.data;
+    },
+    queryKey: getMyMeetingsQueryKey(localStorageKey),
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/domains/meeting/pages/index.test.tsx
+++ b/src/domains/meeting/pages/index.test.tsx
@@ -1,7 +1,9 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LandingPage } from "@/domains/meeting/pages";
+
+const useMyMeetingsQueryMock = vi.fn();
 
 vi.mock("@/domains/meeting/hooks/use-meeting-stats-query", () => ({
   useMeetingStatsQuery: () => ({
@@ -9,7 +11,54 @@ vi.mock("@/domains/meeting/hooks/use-meeting-stats-query", () => ({
   }),
 }));
 
+vi.mock("@/domains/meeting/hooks/use-my-meetings-query", () => ({
+  useMyMeetingsQuery: () => useMyMeetingsQueryMock(),
+}));
+
 describe("LandingPage", () => {
+  beforeEach(() => {
+    useMyMeetingsQueryMock.mockReturnValue({
+      data: [],
+      isError: false,
+      isPending: false,
+    });
+  });
+
+  it("renders recently joined meetings when my meeting data exists", () => {
+    useMyMeetingsQueryMock.mockReturnValue({
+      data: [
+        {
+          createdAt: "2026-07-23T14:10:00",
+          hostName: "민수",
+          isHost: true,
+          meetingId: "meeting-id",
+          participantCount: 4,
+        },
+      ],
+      isError: false,
+      isPending: false,
+    });
+
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain("최근 모임");
+    expect(markup).toContain("민수님의 모임");
+  });
+
+  it("does not render the recent meetings section when my meeting data is empty", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    expect(markup).not.toContain("최근 모임");
+  });
+
   it("renders the service contact email on the landing page", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>

--- a/src/domains/meeting/pages/index.tsx
+++ b/src/domains/meeting/pages/index.tsx
@@ -6,7 +6,9 @@ import {
 import MoyeorakLogo from "@/assets/moyeorak-logo.svg?react";
 import { LandingGuideSection } from "@/domains/meeting/components/landing-guide-section";
 import { LandingStatsBadge } from "@/domains/meeting/components/landing-stats-badge";
+import { MyMeetingList } from "@/domains/meeting/components/my-meeting-list";
 import { useMeetingStatsQuery } from "@/domains/meeting/hooks/use-meeting-stats-query";
+import { useMyMeetingsQuery } from "@/domains/meeting/hooks/use-my-meetings-query";
 import { ChevronDownIcon } from "@/shared/components/icons";
 import { MainButton } from "@/shared/components/main-button";
 import { MobileLayout } from "@/shared/components/mobile-layout";
@@ -14,6 +16,9 @@ import { MobileLayout } from "@/shared/components/mobile-layout";
 export function LandingPage() {
   const navigate = useNavigate();
   const { data: meetingStats } = useMeetingStatsQuery();
+  const { data: myMeetings = [], isError: isMyMeetingsError } =
+    useMyMeetingsQuery();
+  const visibleMyMeetings = isMyMeetingsError ? [] : myMeetings;
 
   return (
     <MobileLayout>
@@ -48,6 +53,11 @@ export function LandingPage() {
             onClick={() => navigate("/new/location")}
           />
         </div>
+
+        <MyMeetingList
+          meetings={visibleMyMeetings}
+          onSelect={(meetingId) => navigate(`/meetings/${meetingId}/schedule`)}
+        />
 
         <button
           type="button"

--- a/src/domains/meeting/types/meeting-api-types.ts
+++ b/src/domains/meeting/types/meeting-api-types.ts
@@ -14,6 +14,14 @@ export interface LandingStatsResponse {
   todayCreatedMeetingCount: number;
 }
 
+export interface MyMeetingResponse {
+  createdAt: string;
+  hostName: string;
+  isHost: boolean;
+  meetingId: string;
+  participantCount: number;
+}
+
 export interface ScheduleParticipant {
   name: string;
   votedDates: string[];


### PR DESCRIPTION
## 변경 사항
- `/api/meetings/me` 클라이언트 타입과 API 함수를 추가했습니다.
- 랜딩 화면에서 브라우저 키 기준 최근 모임 목록을 조회해 다시 입장할 수 있는 `MyMeetingList`를 추가했습니다.
- 조회 결과가 없거나 에러가 발생하면 최근 모임 섹션을 숨기도록 처리했습니다.

## 검증
- `pnpm exec biome check src/domains/meeting/apis/meeting-api.ts src/domains/meeting/types/meeting-api-types.ts src/domains/meeting/hooks/use-my-meetings-query.ts src/domains/meeting/components/my-meeting-list/index.tsx src/domains/meeting/components/my-meeting-list/index.test.tsx src/domains/meeting/pages/index.tsx src/domains/meeting/pages/index.test.tsx`
- `pnpm exec vitest run --exclude ".worktrees/**" src/domains/meeting/components/my-meeting-list/index.test.tsx src/domains/meeting/pages/index.test.tsx`
- `pnpm build`

Related: #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “최근 모임” section displaying the user’s recent meetings, including host, role, participant count, and creation date.
  * Users can select a meeting to open its schedule.
  * Added automatic retrieval and refresh of the user’s meeting list.

* **Bug Fixes**
  * The recent meetings section is hidden when no meetings are available or loading fails.

* **Tests**
  * Added coverage for meeting list rendering, empty states, and landing-page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->