### PR TITLE
최근 모임 5개 제한 재적용

### DIFF
--- a/src/domains/meeting/components/my-meeting-list/index.test.tsx
+++ b/src/domains/meeting/components/my-meeting-list/index.test.tsx
@@ -31,4 +31,22 @@ describe("MyMeetingList", () => {
 
     expect(markup).toBe("");
   });
+
+  it("renders up to five recent meetings", () => {
+    const meetings = Array.from({ length: 6 }, (_, index) => ({
+      createdAt: `2026-07-${23 - index}T14:10:00`,
+      hostName: `호스트${index + 1}`,
+      isHost: index === 0,
+      meetingId: `meeting-id-${index + 1}`,
+      participantCount: 4,
+    }));
+
+    const markup = renderToStaticMarkup(
+      <MyMeetingList meetings={meetings} onSelect={vi.fn()} />,
+    );
+
+    expect(markup).toContain("호스트1님의 모임");
+    expect(markup).toContain("호스트5님의 모임");
+    expect(markup).not.toContain("호스트6님의 모임");
+  });
 });

--- a/src/domains/meeting/components/my-meeting-list/index.tsx
+++ b/src/domains/meeting/components/my-meeting-list/index.tsx
@@ -1,6 +1,8 @@
 import type { MyMeetingResponse } from "@/domains/meeting/types/meeting-api-types";
 import { ChevronRightIcon } from "@/shared/components/icons";
 
+const RECENT_MEETING_LIMIT = 5;
+
 interface MyMeetingListProps {
   meetings: MyMeetingResponse[];
   onSelect: (meetingId: string) => void;
@@ -18,7 +20,7 @@ export function MyMeetingList({ meetings, onSelect }: MyMeetingListProps) {
       </div>
 
       <ul className="flex flex-col gap-2">
-        {meetings.map((meeting) => (
+        {meetings.slice(0, RECENT_MEETING_LIMIT).map((meeting) => (
           <li key={meeting.meetingId}>
             <button
               type="button"


### PR DESCRIPTION
## 변경 사항
- 최근 모임 섹션이 6개 이상의 데이터를 받아도 최대 5개까지만 렌더링하도록 제한을 다시 적용했습니다.
- 이전 PR의 merge 결과에서 누락된 제한 회귀를 방지하기 위해 컴포넌트 테스트를 함께 추가했습니다.

## 확인한 원인
- 운영 번들 `/assets/index-Pp5y2azs.js`와 `main` merge commit `f9ab800`에 `meetings.slice(0, 5)`가 포함되지 않았습니다.
- 제한 커밋은 feature 브랜치에는 있었지만 최종 `main` merge 결과에는 반영되지 않았습니다.

## 검증
- `pnpm exec vitest run --exclude ".worktrees/**" src/domains/meeting/components/my-meeting-list/index.test.tsx`에서 RED 확인
- `pnpm exec biome check src/domains/meeting/components/my-meeting-list/index.tsx src/domains/meeting/components/my-meeting-list/index.test.tsx`
- `pnpm exec vitest run --exclude ".worktrees/**" src/domains/meeting/components/my-meeting-list/index.test.tsx src/domains/meeting/pages/index.test.tsx`
- `pnpm build`
- 로컬 빌드 번들에서 `e.slice(0,HD).map(...)` 포함 확인

Related: #152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The meeting list now displays up to five of the most recent meetings.

* **Bug Fixes**
  * Prevented older meetings from appearing beyond the five-meeting limit.

* **Tests**
  * Added coverage to verify that only the five most recent meetings are rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->