### PR TITLE
feat(location): 출발지 부족 화면 UX 개선

### DIFF
--- a/src/domains/location/components/insufficient-departures-empty-state/index.test.tsx
+++ b/src/domains/location/components/insufficient-departures-empty-state/index.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { InsufficientDeparturesEmptyState } from "@/domains/location/components/insufficient-departures-empty-state";
+
+describe("InsufficientDeparturesEmptyState", () => {
+  it("renders the location shortage state with a character graphic", () => {
+    const markup = renderToStaticMarkup(
+      <InsufficientDeparturesEmptyState
+        content={{
+          title: "내 출발지를 추가하면 중간지점을 찾을 수 있어요",
+          description: null,
+          progressText: "출발지 등록 1 / 5",
+          remainingText: "중간지점 추천까지 1명 더 필요해요",
+          helperText: null,
+          totalStatusText: null,
+          primaryAction: "add",
+          secondaryAction: "share",
+        }}
+        onAddDeparture={() => undefined}
+        onShare={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("내 출발지를 추가하면 중간지점을 찾을 수 있어요");
+    expect(markup).toContain("출발지 등록 1 / 5");
+    expect(markup).toContain("중간지점 추천까지 1명 더 필요해요");
+    expect(markup).not.toContain("전체 5명 중 1명이 등록했어요");
+    expect(markup).not.toContain("내 출발지만 추가하면 결과를 볼 수 있어요");
+    expect(markup).not.toContain("결과가 자동으로 표시돼요");
+    expect(markup).toContain('aria-label="출발지 부족 안내 캐릭터"');
+  });
+});

--- a/src/domains/location/components/insufficient-departures-empty-state/index.tsx
+++ b/src/domains/location/components/insufficient-departures-empty-state/index.tsx
@@ -1,0 +1,63 @@
+import { Empty1Character } from "@/assets/characters";
+import type { InsufficientDepartureContent } from "@/domains/location/utils/insufficient-departures";
+
+export function InsufficientDeparturesEmptyState({
+  content,
+  onAddDeparture,
+  onShare,
+}: {
+  content: InsufficientDepartureContent;
+  onAddDeparture: () => void;
+  onShare: () => void;
+}) {
+  const secondaryActionLabel =
+    content.secondaryAction === "add"
+      ? "출발지 직접 추가하기"
+      : content.secondaryAction === "share"
+        ? "초대 링크 공유하기"
+        : null;
+  const handleSecondaryAction =
+    content.secondaryAction === "add"
+      ? onAddDeparture
+      : content.secondaryAction === "share"
+        ? onShare
+        : undefined;
+
+  return (
+    <div className="grid min-h-0 flex-1 place-items-center">
+      <div className="flex max-w-[320px] flex-col items-center text-center">
+        <Empty1Character
+          aria-label="출발지 부족 안내 캐릭터"
+          className="h-[92px] w-auto"
+        />
+        <div className="mt-4 flex flex-col items-center gap-3">
+          <p className="text-k-700 text-t1">{content.title}</p>
+          {content.description && (
+            <p className="text-b4 text-k-500">{content.description}</p>
+          )}
+          <div className="flex flex-col items-center gap-1.5">
+            <p className="rounded-full bg-p-50 px-3 py-1 text-b4 text-primary-main">
+              {content.progressText}
+            </p>
+            <p className="text-b4 text-k-500">{content.remainingText}</p>
+            {content.totalStatusText && (
+              <p className="text-b4 text-k-400">{content.totalStatusText}</p>
+            )}
+          </div>
+          {content.helperText && (
+            <p className="text-b4 text-k-400">{content.helperText}</p>
+          )}
+          {secondaryActionLabel && handleSecondaryAction && (
+            <button
+              type="button"
+              className="mt-1 text-b3 text-primary-main underline-offset-2 enabled:active:text-p-500 enabled:hover:underline"
+              onClick={handleSecondaryAction}
+            >
+              {secondaryActionLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
+++ b/src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx
@@ -8,6 +8,7 @@ import {
 import PlaceholderGraphic from "@/assets/graphic/placeholder.svg?react";
 import { BottomSheet } from "@/domains/location/components/bottom-sheet";
 import { CardLocationMember } from "@/domains/location/components/card-location-member";
+import { InsufficientDeparturesEmptyState } from "@/domains/location/components/insufficient-departures-empty-state";
 import { MapMarker } from "@/domains/location/components/map-marker";
 import { NearbyDeparturesNote } from "@/domains/location/components/nearby-departures-note";
 import { NearbyPlacesFloatingButton } from "@/domains/location/components/nearby-places-floating-button";
@@ -26,7 +27,9 @@ import {
   formatDepartureDateTime,
   formatDuration,
 } from "@/domains/location/utils/format";
+import { getInsufficientDepartureContent } from "@/domains/location/utils/insufficient-departures";
 import { shouldShowNearbyDepartureNote } from "@/domains/location/utils/midpoint-result";
+import { useGetMyParticipant } from "@/domains/schedule/hooks/use-get-my-participant";
 import { BottomActionBarWithButtonAndShare } from "@/shared/components/bottom-action-bar-with-button-and-share";
 import { ChipButton } from "@/shared/components/chip-button";
 import {
@@ -79,6 +82,7 @@ export function LocationMainPage() {
     meetingId,
     ...LOCATION_MIDPOINT_RESULT_LIVE_QUERY_OPTIONS,
   });
+  const { data: myInfo } = useGetMyParticipant({ meetingId });
   const { data: midpoint, isLoading: isMidpointLoading } =
     useGetMidpointRecommendations({
       meetingId,
@@ -151,6 +155,15 @@ export function LocationMainPage() {
   const registeredCount = midpoint?.registeredCount ?? departureCount;
   const totalCount = midpoint?.totalCount ?? departureCount;
   const hasEnoughDepartures = registeredCount >= 2;
+  const isInsufficientDepartures =
+    !hasRecommendations && !midpoint?.noNearbyStations;
+  const insufficientDepartureContent = isInsufficientDepartures
+    ? getInsufficientDepartureContent({
+        registeredCount,
+        totalCount,
+        hasMyDeparture: myInfo?.locationVoteId != null,
+      })
+    : null;
   const isNearbyDepartures = shouldShowNearbyDepartureNote({
     resultType: midpoint?.resultType,
     recommendations,
@@ -177,6 +190,11 @@ export function LocationMainPage() {
   };
 
   const handleVoteAction = () => {
+    if (insufficientDepartureContent?.primaryAction === "share") {
+      share();
+      return;
+    }
+
     if (hasEnoughDepartures) {
       navigate(`/meetings/${meetingId}/location/votes`);
       return;
@@ -311,10 +329,19 @@ export function LocationMainPage() {
           </div>
         ) : (
           <div className="flex min-h-full flex-col px-5 pb-[106px]">
-            <PlaceholderContent
-              graphic={<PlaceholderGraphic className="h-[90px] w-[104px]" />}
-              title="출발지가 아직 충분하지 않아요"
-              description={`${registeredCount}명 등록됨 · 최소 2명 이상 출발지를 등록하면 중간지점을 추천해드려요`}
+            <InsufficientDeparturesEmptyState
+              content={
+                insufficientDepartureContent ??
+                getInsufficientDepartureContent({
+                  registeredCount,
+                  totalCount,
+                  hasMyDeparture: myInfo?.locationVoteId != null,
+                })
+              }
+              onAddDeparture={() =>
+                navigate(`/meetings/${meetingId}/location/votes/new`)
+              }
+              onShare={share}
             />
           </div>
         )}
@@ -323,8 +350,14 @@ export function LocationMainPage() {
       <BottomActionBarWithButtonAndShare
         onClick={handleVoteAction}
         onShare={share}
+        buttonVariant={insufficientDepartureContent ? "blue" : "white"}
+        showShareButton={insufficientDepartureContent === null}
       >
-        {hasEnoughDepartures ? "출발지 관리하기" : "출발지 추가하기"}
+        {insufficientDepartureContent?.primaryAction === "share"
+          ? "초대 링크 공유하기"
+          : hasEnoughDepartures
+            ? "출발지 관리하기"
+            : "출발지 추가하기"}
       </BottomActionBarWithButtonAndShare>
     </>
   );

--- a/src/domains/location/utils/insufficient-departures.test.ts
+++ b/src/domains/location/utils/insufficient-departures.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { getInsufficientDepartureContent } from "./insufficient-departures";
+
+describe("getInsufficientDepartureContent", () => {
+  it("출발지가 없으면 첫 출발지 등록을 유도한다", () => {
+    expect(
+      getInsufficientDepartureContent({
+        registeredCount: 0,
+        totalCount: 5,
+        hasMyDeparture: false,
+      }),
+    ).toEqual({
+      title: "출발지를 등록하면 중간지점을 찾을 수 있어요",
+      description: null,
+      progressText: "출발지 등록 0 / 5",
+      remainingText: "중간지점 추천까지 2명 더 필요해요",
+      helperText: null,
+      totalStatusText: null,
+      primaryAction: "add",
+      secondaryAction: "share",
+    });
+  });
+
+  it("내 출발지가 등록되어 있으면 공유를 우선 행동으로 안내한다", () => {
+    expect(
+      getInsufficientDepartureContent({
+        registeredCount: 1,
+        totalCount: 5,
+        hasMyDeparture: true,
+      }),
+    ).toEqual({
+      title: "한 명만 더 등록하면 중간지점을 찾을 수 있어요",
+      description: null,
+      progressText: "출발지 등록 1 / 5",
+      remainingText: "중간지점 추천까지 1명 더 필요해요",
+      helperText: null,
+      totalStatusText: null,
+      primaryAction: "share",
+      secondaryAction: "add",
+    });
+  });
+
+  it("내 출발지가 없고 다른 출발지가 있으면 내 출발지 추가를 우선 행동으로 안내한다", () => {
+    expect(
+      getInsufficientDepartureContent({
+        registeredCount: 1,
+        totalCount: 5,
+        hasMyDeparture: false,
+      }),
+    ).toEqual({
+      title: "내 출발지를 추가하면 중간지점을 찾을 수 있어요",
+      description: null,
+      progressText: "출발지 등록 1 / 5",
+      remainingText: "중간지점 추천까지 1명 더 필요해요",
+      helperText: null,
+      totalStatusText: null,
+      primaryAction: "add",
+      secondaryAction: "share",
+    });
+  });
+
+  it("2명 모임이면 전체 참여 현황 보조 문구를 생략한다", () => {
+    expect(
+      getInsufficientDepartureContent({
+        registeredCount: 1,
+        totalCount: 2,
+        hasMyDeparture: true,
+      }).totalStatusText,
+    ).toBeNull();
+  });
+
+  it("전체 인원 수가 0명으로 오면 진행 상태 분모는 최소 추천 조건으로 대체한다", () => {
+    expect(
+      getInsufficientDepartureContent({
+        registeredCount: 0,
+        totalCount: 0,
+        hasMyDeparture: false,
+      }).progressText,
+    ).toBe("출발지 등록 0 / 2");
+  });
+
+  it("내 출발지를 등록한 뒤에는 친구 공유를 유도한다", () => {
+    expect(
+      getInsufficientDepartureContent({
+        registeredCount: 1,
+        totalCount: 5,
+        hasMyDeparture: true,
+      }),
+    ).toMatchObject({
+      title: "한 명만 더 등록하면 중간지점을 찾을 수 있어요",
+      description: null,
+      primaryAction: "share",
+      secondaryAction: "add",
+    });
+  });
+});

--- a/src/domains/location/utils/insufficient-departures.ts
+++ b/src/domains/location/utils/insufficient-departures.ts
@@ -1,0 +1,96 @@
+const MIN_DEPARTURE_COUNT = 2;
+
+export type InsufficientDepartureAction = "add" | "share";
+
+export interface GetInsufficientDepartureContentParams {
+  registeredCount: number;
+  totalCount?: number;
+  hasMyDeparture: boolean;
+}
+
+export interface InsufficientDepartureContent {
+  title: string;
+  description: string | null;
+  progressText: string;
+  remainingText: string;
+  helperText: string | null;
+  totalStatusText: string | null;
+  primaryAction: InsufficientDepartureAction;
+  secondaryAction: InsufficientDepartureAction | null;
+}
+
+function formatPersonCount(count: number) {
+  return `${count}명`;
+}
+
+function getProgressText({
+  registeredCount,
+  totalCount,
+}: {
+  registeredCount: number;
+  totalCount?: number;
+}) {
+  const baseTotalCount =
+    totalCount && totalCount > 0 ? totalCount : MIN_DEPARTURE_COUNT;
+  const denominator = Math.max(baseTotalCount, registeredCount);
+
+  return `출발지 등록 ${registeredCount} / ${denominator}`;
+}
+
+function getRemainingText(remainingCount: number) {
+  return `중간지점 추천까지 ${formatPersonCount(remainingCount)} 더 필요해요`;
+}
+
+export function getInsufficientDepartureContent({
+  registeredCount,
+  totalCount,
+  hasMyDeparture,
+}: GetInsufficientDepartureContentParams): InsufficientDepartureContent {
+  const normalizedRegisteredCount = Math.max(registeredCount, 0);
+  const remainingCount = Math.max(
+    MIN_DEPARTURE_COUNT - normalizedRegisteredCount,
+    0,
+  );
+  const progressText = getProgressText({
+    registeredCount: normalizedRegisteredCount,
+    totalCount,
+  });
+  const remainingText = getRemainingText(remainingCount);
+
+  if (normalizedRegisteredCount === 0) {
+    return {
+      title: "출발지를 등록하면 중간지점을 찾을 수 있어요",
+      description: null,
+      progressText,
+      remainingText,
+      helperText: null,
+      totalStatusText: null,
+      primaryAction: "add",
+      secondaryAction: "share",
+    };
+  }
+
+  if (!hasMyDeparture) {
+    return {
+      title: "내 출발지를 추가하면 중간지점을 찾을 수 있어요",
+      description: null,
+      progressText,
+      remainingText,
+      helperText: null,
+      totalStatusText: null,
+      primaryAction: "add",
+      secondaryAction: "share",
+    };
+  }
+
+  return {
+    title: "한 명만 더 등록하면 중간지점을 찾을 수 있어요",
+    description: null,
+    progressText,
+    remainingText,
+    helperText: null,
+    totalStatusText: null,
+    primaryAction: "share",
+    secondaryAction: "add",
+  };
+}

--- a/src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx
+++ b/src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx
@@ -28,4 +28,19 @@ describe("BottomActionBarWithButtonAndShare", () => {
     expect(markup).toContain("bg-primary-main");
     expect(markup).toContain("border-k-200");
   });
+
+  it("can hide the icon share CTA when sharing is the main labeled action", () => {
+    const markup = renderToStaticMarkup(
+      <BottomActionBarWithButtonAndShare
+        onClick={() => undefined}
+        onShare={() => undefined}
+        showShareButton={false}
+      >
+        초대 링크 공유하기
+      </BottomActionBarWithButtonAndShare>,
+    );
+
+    expect(markup).toContain("초대 링크 공유하기");
+    expect(markup).not.toContain('aria-label="공유하기"');
+  });
 });

--- a/src/shared/components/bottom-action-bar-with-button-and-share/index.tsx
+++ b/src/shared/components/bottom-action-bar-with-button-and-share/index.tsx
@@ -16,6 +16,7 @@ export interface BottomActionBarWithButtonAndShareProps {
   children?: ReactNode;
   className?: string;
   buttonVariant?: "black" | "blue" | "white";
+  showShareButton?: boolean;
 }
 
 export function BottomActionBarWithButtonAndShare({
@@ -26,22 +27,25 @@ export function BottomActionBarWithButtonAndShare({
   children,
   className,
   buttonVariant = "white",
+  showShareButton = true,
 }: BottomActionBarWithButtonAndShareProps) {
   return (
     <BottomActionBar
       tone={tone}
       className={cn("flex items-center gap-2", className)}
     >
-      <IconButton
-        aria-label="공유하기"
-        background="square"
-        backgroundSize="lg"
-        icon={ShareIcon}
-        iconSize="xl"
-        onClick={onShare}
-        size="2xl"
-        variant="primary"
-      />
+      {showShareButton && (
+        <IconButton
+          aria-label="공유하기"
+          background="square"
+          backgroundSize="lg"
+          icon={ShareIcon}
+          iconSize="xl"
+          onClick={onShare}
+          size="2xl"
+          variant="primary"
+        />
+      )}
       <ButtonBottom
         disabled={disabled}
         onClick={onClick}


### PR DESCRIPTION
## Summary
- 출발지 부족 상태를 캐릭터 기반 empty state 컴포넌트로 분리했습니다.
- 내 출발지 등록 여부에 따라 메인 CTA를 `출발지 추가하기` 또는 `초대 링크 공유하기`로 분기했습니다.
- 진행 배지를 전체 인원 기준 `n / N`으로 표시하고, 중복 설명 문구를 줄였습니다.
- 공유가 메인 CTA일 때 하단 공유 아이콘을 숨길 수 있도록 액션바 옵션을 추가했습니다.

## Validation
- `pnpm exec biome check src/domains/location/components/insufficient-departures-empty-state/index.tsx src/domains/location/components/insufficient-departures-empty-state/index.test.tsx 'src/domains/location/pages/meetings/[meeting-id]/location/stations/index.tsx' src/domains/location/utils/insufficient-departures.ts src/domains/location/utils/insufficient-departures.test.ts src/shared/components/bottom-action-bar-with-button-and-share/index.tsx src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx`
- `pnpm exec vitest run --exclude '.worktrees/**' src/domains/location/components/insufficient-departures-empty-state/index.test.tsx src/domains/location/utils/insufficient-departures.test.ts src/shared/components/bottom-action-bar-with-button-and-share/index.test.tsx`
- `pnpm exec tsc -b --pretty false`
- `pnpm build`